### PR TITLE
[#20] feat: b2c 상품 단건 조회 기능 추가

### DIFF
--- a/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
+++ b/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
@@ -1,12 +1,10 @@
 package com.sparta.b2c;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication
+@SpringBootApplication(exclude = { SecurityAutoConfiguration.class })
 public class B2cApplication {
 
     public static void main(String[] args) {

--- a/b2c/src/main/java/com/sparta/b2c/product/config/JpaConfig.java
+++ b/b2c/src/main/java/com/sparta/b2c/product/config/JpaConfig.java
@@ -1,0 +1,11 @@
+package com.sparta.b2c.product.config;
+
+import org.springframework.boot.autoconfigure.domain.EntityScan;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaRepositories;
+
+@Configuration
+@EntityScan(basePackages = "com.sparta.impostor.commerce.backend")
+@EnableJpaRepositories(basePackages = "com.sparta.impostor.commerce.backend")
+public class JpaConfig {
+}

--- a/b2c/src/main/java/com/sparta/b2c/product/controller/ProductController.java
+++ b/b2c/src/main/java/com/sparta/b2c/product/controller/ProductController.java
@@ -1,0 +1,26 @@
+package com.sparta.b2c.product.controller;
+
+import com.sparta.b2c.product.dto.response.ProductResponse;
+import com.sparta.b2c.product.service.ProductService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+public class ProductController {
+
+    private final ProductService productService;
+
+    @GetMapping("/products/{id}")
+    public ResponseEntity<ProductResponse> retrieveProduct(@PathVariable Long id) {
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(productService.retrieveProduct(id));
+    }
+}

--- a/b2c/src/main/java/com/sparta/b2c/product/dto/response/ProductResponse.java
+++ b/b2c/src/main/java/com/sparta/b2c/product/dto/response/ProductResponse.java
@@ -1,0 +1,18 @@
+package com.sparta.b2c.product.dto.response;
+
+import com.sparta.impostor.commerce.backend.domain.product.enums.Category;
+import com.sparta.impostor.commerce.backend.domain.product.enums.ProductStatus;
+
+import java.time.LocalDateTime;
+
+public record ProductResponse (
+        Long id,
+        String name,
+        String description,
+        int price,
+        ProductStatus status,
+        Category category,
+        Category.SubCategory subCategory,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {}

--- a/b2c/src/main/java/com/sparta/b2c/product/service/ProductService.java
+++ b/b2c/src/main/java/com/sparta/b2c/product/service/ProductService.java
@@ -1,0 +1,30 @@
+package com.sparta.b2c.product.service;
+
+import com.sparta.b2c.product.dto.response.ProductResponse;
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import com.sparta.impostor.commerce.backend.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+    private final ProductRepository productRepository;
+
+    public ProductResponse retrieveProduct(Long id) {
+        Product product = productRepository.findById(id)
+                .orElseThrow(() -> new RuntimeException("404 - 상품을 찾지 못하였습니다."));
+        return new ProductResponse(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getPrice(),
+                product.getStatus(),
+                product.getCategory(),
+                product.getSubCategory(),
+                product.getCreatedAt(),
+                product.getModifiedAt()
+        );
+    }
+}

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/entity/Order.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/entity/Order.java
@@ -10,10 +10,14 @@ import lombok.Getter;
 
 @Entity
 @Getter
+@Table(name = "orders")
 public class Order extends Timestamped {
 
     @Id
     @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
     private String name;
 
     @Column(length = 50)


### PR DESCRIPTION
### $\bf{\normalsize{\color{yellow}GET}}$ `/api/store/{id}/menu`

### 담당자
- 허원경

## 기능 이름
- B2C 특정 상품 단건 조회

## 기능 내용
- 사용자가 특정 상품 하나를 상세히 조회하는 기능의 API
- 상품 상태가 `OFF_SALE`, `PENDING` 는 조회되지 않도록 설정해야 함
- spring security 임시 비활성화
- `order` 테이블 예약어로 인한 테이블면 `orders`로 변경
- `order` 테이블의 name 필드에 pk가 설정되어있던것 올바르게 변경
- b2c에서 domain 모듈을 컴포넌트 스캔을 할 수 있는 설정 추가

예외 처리
- [RuntimeException] : 없는 상품을 조회하려고 하면 예외 발생


<table>
    <tr>
        <th>Requqest Body</th>
        <th>Response Body</th>
    </tr>
    <tr>
        <td><pre lang="json">N/A</pre></td>
        <td><pre lang="json">{
  "id": 1,
  "name": "상품 이름",
  "description": "상품 내용",
  "stockQuantity": "상품 수량",
  "price": 10000,
  "status": "ON_SALE",
  "category": "TOP",
  "subCategory": "T_SHIRT",
  "createdAt": "2024-12-04 00:00:00",
  "modifiedAt": "2024-12-04 00:00:00"
}</pre></td>
    </tr>
</table>
