### PR TITLE
[#12] feat: B2B 주문의 배송 상태 변경

### DIFF
--- a/b2b/src/main/java/com/sparta/b2b/order/controller/OrderController.java
+++ b/b2b/src/main/java/com/sparta/b2b/order/controller/OrderController.java
@@ -1,14 +1,14 @@
 package com.sparta.b2b.order.controller;
 
+import com.sparta.b2b.order.dto.request.DeliveryStatusRequest;
 import com.sparta.b2b.order.dto.response.OrderPageResponse;
+import com.sparta.b2b.order.dto.response.OrderResponse;
 import com.sparta.b2b.order.service.OrderService;
+import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/orders")
@@ -26,6 +26,15 @@ public class OrderController {
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(orderService.retrieveOrderList(page, size, sortBy, orderBy));
+    }
+
+    @PatchMapping("/{id}/deliverystatus")
+    public ResponseEntity<OrderResponse> updateDeliveryStatus(@PathVariable Long id,
+                                                              @RequestBody @Valid DeliveryStatusRequest request) {
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(orderService.updateDeliveryStatus(id, request));
     }
 
 }

--- a/b2b/src/main/java/com/sparta/b2b/order/dto/request/DeliveryStatusRequest.java
+++ b/b2b/src/main/java/com/sparta/b2b/order/dto/request/DeliveryStatusRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.b2b.order.dto.request;
+
+import jakarta.validation.constraints.Size;
+
+public record DeliveryStatusRequest(
+        @Size(min = 12, max = 12, message = "숫자는 12자리여야 합니다.")
+        String trackingNumber
+) {
+}

--- a/b2b/src/main/java/com/sparta/b2b/order/dto/response/OrderResponse.java
+++ b/b2b/src/main/java/com/sparta/b2b/order/dto/response/OrderResponse.java
@@ -7,6 +7,7 @@ import com.sparta.impostor.commerce.backend.domain.order.enums.OrderStatus;
 import java.time.LocalDateTime;
 
 public record OrderResponse(
+        Long id,
         String name,
         String trackingNumber,
         OrderStatus orderStatus,
@@ -21,6 +22,7 @@ public record OrderResponse(
 
     public static OrderResponse from(Order order) {
         return new OrderResponse(
+                order.getId(),
                 order.getName(),
                 order.getTrackingNumber(),
                 order.getOrderStatus(),
@@ -33,4 +35,6 @@ public record OrderResponse(
                 order.getModifiedAt()
         );
     }
+
+
 }

--- a/b2b/src/main/java/com/sparta/b2b/order/service/OrderService.java
+++ b/b2b/src/main/java/com/sparta/b2b/order/service/OrderService.java
@@ -1,6 +1,8 @@
 package com.sparta.b2b.order.service;
 
+import com.sparta.b2b.order.dto.request.DeliveryStatusRequest;
 import com.sparta.b2b.order.dto.response.OrderPageResponse;
+import com.sparta.b2b.order.dto.response.OrderResponse;
 import com.sparta.impostor.commerce.backend.domain.order.entity.Order;
 import com.sparta.impostor.commerce.backend.domain.order.repository.OrderRepository;
 import lombok.RequiredArgsConstructor;
@@ -9,9 +11,11 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 @Service
 @RequiredArgsConstructor
+@Transactional(readOnly = true)
 public class OrderService {
 
     private final OrderRepository orderRepository;
@@ -29,5 +33,20 @@ public class OrderService {
         Page<Order> orders = orderRepository.findAll(pageable);
 
         return new OrderPageResponse(orders);
+    }
+
+    @Transactional
+    public OrderResponse updateDeliveryStatus(Long id, DeliveryStatusRequest request) {
+
+        String trackingNumber = request.trackingNumber();
+
+        Order order = orderRepository.findById(id).orElseThrow(() ->
+                new NullPointerException("주문이 존재하지 않습니다.")
+        );
+
+        Order updatedOrder = order.update(trackingNumber);
+
+        return OrderResponse.from(updatedOrder);
+
     }
 }

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/entity/Order.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/entity/Order.java
@@ -46,4 +46,9 @@ public class Order extends Timestamped {
     private Product product;
 
 
+    public Order update(String trackingNumber) {
+        this.trackingNumber = trackingNumber;
+        this.deliveryStatus = DeliveryStatus.IN_TRANSIT;
+        return this;
+    }
 }


### PR DESCRIPTION
---
name: PR 템플릿
about: Suggest an idea for this project
title: "[#12] feat: B2B 주문의 배송 상태 변경"
labels: ''
assignees: ''

---

## 🔘Part 
-B2B 주문의 배송 상태를 변경합니다.

## 🔎 작업 내용 
- 주문에 운송장 등록 시 주문 상태가 NOT_SHIPPED에서 IN_TRANSIT로 변경 됩니다.
- 12자리 운송번호만 입력 가능합니다.

## 🔧 앞으로의 과제 
- 회원가입 및 로그인 기능 구현

## ➕ 이슈 링크 
- #12 
