### PR TITLE
[#7] Feat/b2c search/7 B2C 회원 조회

### DIFF
--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -8,6 +8,5 @@ tasks.jar {
 }
 
 dependencies {
-    implementation project(':domain')
-}
+  implementation project(':domain')
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -8,5 +8,6 @@ tasks.jar {
 }
 
 dependencies {
-  implementation project(':domain')
+    implementation project(':domain')
+}
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/admin/build.gradle
+++ b/admin/build.gradle
@@ -10,5 +10,4 @@ tasks.jar {
 dependencies {
     implementation project(':domain')
 }
-
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/admin/src/main/java/com/sparta/admin/member/controller/B2CSearchController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2CSearchController.java
@@ -1,0 +1,41 @@
+package com.sparta.admin.member.controller;
+
+import com.sparta.admin.member.dto.response.B2CMemberPageResponse;
+import com.sparta.admin.member.service.B2CSearchService;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.domain.Sort.Direction;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequestMapping("/api/b2c-members")
+@RequiredArgsConstructor
+public class B2CSearchController {
+
+  private final B2CSearchService b2cSearchService;
+
+  // B2C 회원 전체 조회
+  @GetMapping
+  public B2CMemberPageResponse getB2CMembers(
+      @RequestParam(defaultValue = "1") int page,
+      @RequestParam(defaultValue = "10") int size,
+      @RequestParam(defaultValue = "id") String sortBy,
+      @RequestParam(defaultValue = "asc") String orderBy,
+      @RequestParam(required = false) B2CMemberStatus status
+  ) {
+    Sort.Direction direction =
+        orderBy.equalsIgnoreCase("desc") ? Direction.DESC : Sort.Direction.ASC;
+
+    PageRequest pageRequest = PageRequest.of(
+        page - 1,
+        size,
+        Sort.by(direction, sortBy));
+
+    return b2cSearchService.getB2CMembers(status, pageRequest);
+  }
+}

--- a/admin/src/main/java/com/sparta/admin/member/controller/B2CSearchController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2CSearchController.java
@@ -1,5 +1,6 @@
 package com.sparta.admin.member.controller;
 
+import com.sparta.admin.member.dto.request.B2CMemberSearchRequest;
 import com.sparta.admin.member.dto.response.B2CMemberPageResponse;
 import com.sparta.admin.member.service.B2CSearchService;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
@@ -8,6 +9,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Sort;
 import org.springframework.data.domain.Sort.Direction;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
@@ -21,21 +23,27 @@ public class B2CSearchController {
 
   // B2C 회원 전체 조회
   @GetMapping
-  public B2CMemberPageResponse getB2CMembers(
-      @RequestParam(defaultValue = "1") int page,
-      @RequestParam(defaultValue = "10") int size,
-      @RequestParam(defaultValue = "id") String sortBy,
-      @RequestParam(defaultValue = "asc") String orderBy,
-      @RequestParam(required = false) B2CMemberStatus status
-  ) {
-    Sort.Direction direction =
-        orderBy.equalsIgnoreCase("desc") ? Direction.DESC : Sort.Direction.ASC;
+  public B2CMemberPageResponse getB2CMembers(@ModelAttribute B2CMemberSearchRequest request) {
 
-    PageRequest pageRequest = PageRequest.of(
-        page - 1,
-        size,
-        Sort.by(direction, sortBy));
+    request.setDefaults();
 
-    return b2cSearchService.getB2CMembers(status, pageRequest);
+    // DTO 에서 값 추출
+    int page = request.getPage() - 1;
+    int size = request.getSize();
+    String sortBy = request.getSortBy();
+    String orderBy = request.getOrderBy();
+    B2CMemberStatus status = request.getStatus();
+
+    {
+      Sort.Direction direction =
+          orderBy.equalsIgnoreCase("desc") ? Direction.DESC : Sort.Direction.ASC;
+
+      PageRequest pageRequest = PageRequest.of(
+          page,
+          size,
+          Sort.by(direction, sortBy));
+
+      return b2cSearchService.getB2CMembers(status, pageRequest);
+    }
   }
 }

--- a/admin/src/main/java/com/sparta/admin/member/dto/request/B2CMemberSearchRequest.java
+++ b/admin/src/main/java/com/sparta/admin/member/dto/request/B2CMemberSearchRequest.java
@@ -1,0 +1,34 @@
+package com.sparta.admin.member.dto.request;
+
+import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@AllArgsConstructor
+@NoArgsConstructor
+@Getter
+public class B2CMemberSearchRequest {
+
+  private int page;
+  private int size;
+  private String sortBy;
+  private String orderBy;
+  private B2CMemberStatus status;
+
+
+  public void setDefaults() {
+    if (this.page <= 0) {
+      this.page = 1;
+    }
+    if (this.size <= 0) {
+      this.size = 10;
+    }
+    if (this.sortBy == null || this.sortBy.isEmpty()) {
+      this.sortBy = "id";
+    }
+    if (this.orderBy == null || this.orderBy.isEmpty()) {
+      this.orderBy = "asc";
+    }
+  }
+}

--- a/admin/src/main/java/com/sparta/admin/member/dto/response/B2CMemberPageResponse.java
+++ b/admin/src/main/java/com/sparta/admin/member/dto/response/B2CMemberPageResponse.java
@@ -1,0 +1,26 @@
+package com.sparta.admin.member.dto.response;
+
+import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record B2CMemberPageResponse(
+
+    List<B2CMemberResponse> contents,
+    int page,
+    int size,
+    int totalPages
+) {
+
+  public B2CMemberPageResponse(Page<B2CMember> pageResponse) {
+    this(
+        pageResponse.getContent().stream()
+            .map(B2CMemberResponse::from)
+            .toList(),
+        pageResponse.getPageable().getPageNumber() + 1,
+        pageResponse.getPageable().getPageSize(),
+        pageResponse.getTotalPages()
+    );
+  }
+
+}

--- a/admin/src/main/java/com/sparta/admin/member/dto/response/B2CMemberResponse.java
+++ b/admin/src/main/java/com/sparta/admin/member/dto/response/B2CMemberResponse.java
@@ -1,0 +1,22 @@
+package com.sparta.admin.member.dto.response;
+
+import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
+
+public record B2CMemberResponse(
+    Long id,
+    String email,
+    String name,
+    B2CMemberStatus status
+) {
+
+  public static B2CMemberResponse from(B2CMember member) {
+    return new B2CMemberResponse(
+        member.getId(),
+        member.getEmail(),
+        member.getName(),
+        member.getStatus()
+    );
+  }
+
+}

--- a/admin/src/main/java/com/sparta/admin/member/service/B2CSearchService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/B2CSearchService.java
@@ -1,0 +1,33 @@
+package com.sparta.admin.member.service;
+
+import com.sparta.admin.member.dto.response.B2CMemberPageResponse;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.repository.B2CMemberRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class B2CSearchService {
+
+  private final B2CMemberRepository b2cMemberRepository;
+
+  // B2C 회원 조회 ( 전체 조회, 상태별 조회, 페이지네이션, 정렬 적용)
+  public B2CMemberPageResponse getB2CMembers(B2CMemberStatus status, PageRequest pageRequest) {
+    Page<B2CMember> b2cMembers;
+
+    // status 파라미터에 따라 필터링
+    if (status != null) {
+      // 상태에 맞는 회원들만 조회
+      b2cMembers = b2cMemberRepository.findByB2CMemberStatus(status, pageRequest);
+    } else {
+      // 상태가 주어지지 않으면, 모든 회원 조회
+      b2cMembers = b2cMemberRepository.findAll(pageRequest);
+    }
+
+    return new B2CMemberPageResponse(b2cMembers);
+  }
+}

--- a/admin/src/main/java/com/sparta/admin/member/service/MemberAuthService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/MemberAuthService.java
@@ -1,5 +1,0 @@
-package com.sparta.admin.member.service;
-
-public class MemberAuthService {
-
-}

--- a/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
+++ b/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(scanBasePackages = {"com.sparta.impostor.commerce.backend", "com.sparta.b2c"}, exclude = { SecurityAutoConfiguration.class })
+@SpringBootApplication(scanBasePackages = "com.sparta.impostor", exclude = { SecurityAutoConfiguration.class })
 public class B2cApplication {
 
     public static void main(String[] args) {

--- a/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
+++ b/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
@@ -4,7 +4,7 @@ import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;
 
-@SpringBootApplication(scanBasePackages = "com.sparta.impostor", exclude = { SecurityAutoConfiguration.class })
+@SpringBootApplication(scanBasePackages = "com.sparta", exclude = { SecurityAutoConfiguration.class })
 public class B2cApplication {
 
     public static void main(String[] args) {

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/b2cMember/repository/B2CMemberRepository.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/b2cMember/repository/B2CMemberRepository.java
@@ -1,7 +1,13 @@
 package com.sparta.impostor.commerce.backend.domain.b2cMember.repository;
 
 import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface B2CMemberRepository extends JpaRepository<B2CMember, Long> {
+
+  // 상태에 맞는 B2C 회원 조회
+  Page<B2CMember> findByB2CMemberStatus(B2CMemberStatus b2cMemberStatus, PageRequest pageRequest);
 }


### PR DESCRIPTION
- 제목 : [#7] feat: B2C 회원 조회 API 구현


## 🔘Part 
- B2C 회원 조회 API 구현 및 예외 처리 추가

## 🔎 작업 내용 
- B2C 회원 조회 기능을 추가하고 status 파라미터를 활용하여 
'B2C 회원 전체 조회' 및 '활성화된 회원'과 '비활성화된 회원'을 구분하여 조회할 수 있도록 구현하였습니다.

### - B2C 회원 전체조회 API
GET /api/b2c-members

### - 상태별 B2C 회원 조회 API
예시) 상태가 ACTIVE인 B2C 회원을 조회하며, 페이지는 1, 사이즈는 10, 이름 기준으로 오름차순 정렬.
GET /api/b2c-members?status=ACTIVE&page=1&size=10&sortBy=name&orderBy=asc


## 🔧 앞으로의 과제 
- B2B 등록 요청 승인 및 거절 < 진행 예정

## ➕ 이슈 링크 
- #7 
