### PR TITLE
[#10] feat: B2C 주문등록 기능 구현

### DIFF
--- a/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
+++ b/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
@@ -1,5 +1,7 @@
 package com.sparta.b2c;
 
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;

--- a/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
+++ b/b2c/src/main/java/com/sparta/b2c/B2cApplication.java
@@ -1,7 +1,5 @@
 package com.sparta.b2c;
 
-import com.querydsl.jpa.impl.JPAQueryFactory;
-import jakarta.persistence.EntityManager;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.boot.autoconfigure.security.servlet.SecurityAutoConfiguration;

--- a/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
@@ -19,6 +19,7 @@ public class OrderController {
     @PostMapping()
     public ResponseEntity<OrderResponse>createOrder(@Valid @RequestBody OrderRequest orderRequest) {
 
+        // b2c 로그인 구현 후 로그인 값 변경 예정
         OrderResponse orderResponse = orderService.createOrder(1L, orderRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(orderResponse);
     }

--- a/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
@@ -1,0 +1,26 @@
+package com.sparta.b2c.order.controller;
+
+import com.sparta.b2c.order.dto.request.OrderRequest;
+import com.sparta.b2c.order.dto.response.OrderResponse;
+import com.sparta.b2c.order.service.OrderService;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/orders")
+public class OrderController {
+
+    private final OrderService orderService;
+
+    @PostMapping()
+    public ResponseEntity<OrderResponse>createOrder(@Valid @RequestBody OrderRequest orderRequest) {
+
+        OrderResponse orderResponse = orderService.createOrder(1L, orderRequest);
+        return ResponseEntity.status(HttpStatus.CREATED).body(orderResponse);
+    }
+
+}

--- a/b2c/src/main/java/com/sparta/b2c/order/dto/request/OrderRequest.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/dto/request/OrderRequest.java
@@ -1,0 +1,19 @@
+package com.sparta.b2c.order.dto.request;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class OrderRequest {
+
+    @NotNull
+    private Long productId;
+
+    @Positive
+    @Min(value = 1, message = "수량은 1보다 작을 수 없습니다.")
+    private int quantity;
+}

--- a/b2c/src/main/java/com/sparta/b2c/order/dto/request/OrderRequest.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/dto/request/OrderRequest.java
@@ -3,17 +3,14 @@ package com.sparta.b2c.order.dto.request;
 import jakarta.validation.constraints.Min;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
 
-@Getter
-@NoArgsConstructor
-public class OrderRequest {
+public record OrderRequest(
 
     @NotNull
-    private Long productId;
+    Long productId,
 
     @Positive
     @Min(value = 1, message = "수량은 1보다 작을 수 없습니다.")
-    private int quantity;
+    int quantity
+) {
 }

--- a/b2c/src/main/java/com/sparta/b2c/order/dto/response/OrderResponse.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/dto/response/OrderResponse.java
@@ -1,0 +1,34 @@
+package com.sparta.b2c.order.dto.response;
+
+import com.sparta.impostor.commerce.backend.domain.order.entity.Order;
+import com.sparta.impostor.commerce.backend.domain.order.enums.DeliveryStatus;
+import com.sparta.impostor.commerce.backend.domain.order.enums.OrderStatus;
+
+import java.time.LocalDateTime;
+
+public record OrderResponse(
+        Long id,
+        String name,
+        int quantity,
+        Long totalPrice,
+        OrderStatus status,
+        DeliveryStatus deliveryStatus,
+        String trackingNumber,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+
+    public static OrderResponse from(Order order) {
+        return new OrderResponse(
+          order.getId(),
+          order.getName(),
+          order.getQuantity(),
+          order.getTotalPrice(),
+          order.getOrderStatus(),
+          order.getDeliveryStatus(),
+          order.getTrackingNumber(),
+          order.getCreatedAt(),
+          order.getModifiedAt()
+        );
+    }
+}

--- a/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
@@ -1,0 +1,60 @@
+package com.sparta.b2c.order.service;
+
+import com.sparta.b2c.order.dto.request.OrderRequest;
+import com.sparta.b2c.order.dto.response.OrderResponse;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.repository.B2CMemberRepository;
+import com.sparta.impostor.commerce.backend.domain.order.entity.Order;
+import com.sparta.impostor.commerce.backend.domain.order.enums.DeliveryStatus;
+import com.sparta.impostor.commerce.backend.domain.order.enums.OrderStatus;
+import com.sparta.impostor.commerce.backend.domain.order.repository.OrderRepository;
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import com.sparta.impostor.commerce.backend.domain.product.repository.ProductRepository;
+import jakarta.persistence.EntityNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+public class OrderService {
+
+    private final OrderRepository orderRepository;
+    private final ProductRepository productRepository;
+    private final B2CMemberRepository b2cMemberRepository;
+
+    @Transactional
+    public OrderResponse createOrder(Long b2cMemberId, OrderRequest orderRequest) {
+
+        B2CMember b2CMember = b2cMemberRepository.findById(b2cMemberId)
+                .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
+
+        Product product = productRepository.findById(orderRequest.getProductId())
+                .orElseThrow(() -> new EntityNotFoundException("상품을 찾을 수 없습니다."));
+
+        // 상품의 수량이 주문 수량의 이상인지 검증
+        int quantity = orderRequest.getQuantity();
+        if (quantity > product.getStockQuantity()) {
+            throw new IllegalArgumentException("재고 수량이 부족합니다.");
+        }
+
+        Long totalPrice = Long.valueOf(product.getPrice() * quantity);
+
+        Order order = Order.create(
+                product.getName(),
+                quantity,
+                totalPrice,
+                OrderStatus.CONFIRMED,
+                DeliveryStatus.NOT_SHIPPED,
+                "",   // trackingNumber 초기 값
+                product,
+                b2CMember,
+                product.getId()
+        );
+
+        orderRepository.save(order);
+        return OrderResponse.from(order);
+
+    }
+}

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/entity/Order.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/entity/Order.java
@@ -7,10 +7,12 @@ import com.sparta.impostor.commerce.backend.domain.order.enums.OrderStatus;
 import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
 import jakarta.persistence.*;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Entity
 @Getter
 @Table(name = "orders")
+@NoArgsConstructor
 public class Order extends Timestamped {
 
     @Id
@@ -20,8 +22,11 @@ public class Order extends Timestamped {
     @Column(nullable = false)
     private String name;
 
-    @Column(length = 50)
-    private String trackingNumber;
+    @Column(nullable = false)
+    private int quantity;
+
+    @Column(nullable = false)
+    private Long totalPrice;
 
     @Column(nullable = false)
     @Enumerated(EnumType.STRING)
@@ -31,15 +36,15 @@ public class Order extends Timestamped {
     @Enumerated(EnumType.STRING)
     private DeliveryStatus deliveryStatus;
 
-    @Column(nullable = false)
-    private Long totalPrice;
-
-    @Column(nullable = false)
-    private Long quantity;
+    @Column(length = 50, nullable = false)
+    private String trackingNumber;
 
     @ManyToOne
-    @JoinColumn(name = "member_id")
-    private B2CMember member;
+    @JoinColumn(name = "b2cmember_id")
+    private B2CMember b2CMember;
+
+    @Column(nullable = false)
+    private Long b2BMemberId;
 
     @ManyToOne
     @JoinColumn(name = "product_id")
@@ -51,4 +56,21 @@ public class Order extends Timestamped {
         this.deliveryStatus = DeliveryStatus.IN_TRANSIT;
         return this;
     }
+
+    private Order(String name, int quantity, Long totalPrice, OrderStatus orderStatus, DeliveryStatus deliveryStatus, String trackingNumber, Product product, B2CMember b2CMember, Long b2BMemberId) {
+        this.name = name;
+        this.quantity = quantity;
+        this.totalPrice = totalPrice;
+        this.orderStatus = orderStatus;
+        this.deliveryStatus = deliveryStatus;
+        this.trackingNumber = trackingNumber;
+        this.product = product;
+        this.b2CMember = b2CMember;
+        this.b2BMemberId = b2BMemberId;
+    }
+
+    public static Order create(String name, int quantity, Long totalPrice, OrderStatus orderStatus, DeliveryStatus deliveryStatus, String trackingNumber, Product product, B2CMember b2CMember, Long b2BMemberId) {
+        return new Order(name, quantity, totalPrice, orderStatus, deliveryStatus, trackingNumber, product, b2CMember, b2BMemberId);
+    }
+
 }


### PR DESCRIPTION
## 🔘Part 
-B2C 주문 등록 기능 구현

## 🔎 작업 내용 
- 주문등록 기능 추가
- 주문상태: 기본값 CONFIRMED
- 배송상태: 기본값 NOT_SHIPPED
- B2CmemberId와 productId의 유효성 검증
- 주문 수량이 재고 수량을 초과하지 않는지 검증

## 🔧 앞으로의 과제 
- 주문 목록 조회 기능 구현

## ➕ 이슈 링크 
- #10
