### PR TITLE
[#53] test: B2C 상품 검색 & 상품 단건 조회 테스트코드

### DIFF
--- a/b2c/build.gradle
+++ b/b2c/build.gradle
@@ -10,6 +10,7 @@ tasks.jar {
 dependencies {
     implementation project(':domain')
     implementation project(':common')
+    testImplementation 'com.h2database:h2'
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/b2c/src/test/java/com/sparta/b2c/product/service/ProductServiceIntegrationTest.java
+++ b/b2c/src/test/java/com/sparta/b2c/product/service/ProductServiceIntegrationTest.java
@@ -1,0 +1,166 @@
+package com.sparta.b2c.product.service;
+
+import com.sparta.b2c.product.dto.request.ProductSearchRequest;
+import com.sparta.b2c.product.dto.response.PageProductResponse;
+import com.sparta.b2c.product.dto.response.ProductResponse;
+import com.sparta.impostor.commerce.backend.common.config.JPAConfiguration;
+import com.sparta.impostor.commerce.backend.common.config.PasswordEncoderConfig;
+import com.sparta.impostor.commerce.backend.domain.b2bMember.entity.B2BMember;
+import com.sparta.impostor.commerce.backend.domain.b2bMember.repository.B2BMemberRepository;
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import com.sparta.impostor.commerce.backend.domain.product.enums.Category;
+import com.sparta.impostor.commerce.backend.domain.product.enums.ProductStatus;
+import com.sparta.impostor.commerce.backend.domain.product.repository.ProductRepository;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.TestInstance;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Arrays;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@TestInstance(TestInstance.Lifecycle.PER_CLASS)
+@DataJpaTest
+@Import(value = {JPAConfiguration.class, ProductService.class, PasswordEncoderConfig.class})
+public class ProductServiceIntegrationTest {
+
+    @Autowired
+    private ProductService productService;
+
+    @Autowired
+    private ProductRepository productRepository;
+
+    @Autowired
+    private B2BMemberRepository b2BMemberRepository;
+
+    @Autowired
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @BeforeAll
+    public void setUp() {
+        // 상품을 등록하기 위한 멤버 생성
+        String password = passwordEncoder.encode("password1");
+        B2BMember createMember = B2BMember.createMember(
+                "seller1@email.com",
+                password,
+                "판매자1");
+        b2BMemberRepository.save(createMember);
+
+        // ON SALE 상태의 상품 15개 DB에 생성
+        for (int i = 0; i < 15; i++) {
+            String productName = String.format("상품%03d", i + 1);
+            productRepository.save(Product.createProduct(
+                    productName,
+                    "상품 설명",
+                    100,
+                    100 * (i + 1),
+                    ProductStatus.ON_SALE,
+                    Category.TOP,
+                    Category.SubCategory.T_SHIRT
+            ));
+        }
+
+        // PENDING 상태의 상품 한 개 DB에 생성
+        productRepository.save(Product.createProduct(
+                "미판매 상품",
+                "판매 준비 중 입니다.",
+                100,
+                10000,
+                ProductStatus.PENDING,
+                Category.TOP,
+                Category.SubCategory.T_SHIRT
+        ));
+
+        // OFF_SALE 상태의 상품 한 개 DB에 생성
+        productRepository.save(Product.createProduct(
+                "미판매 상품2",
+                "판매 중비된 상품 입니다.",
+                100,
+                10000,
+                ProductStatus.OFF_SALE,
+                Category.TOP,
+                Category.SubCategory.T_SHIRT
+        ));
+    }
+
+
+    @Test
+    @DisplayName("상품 검색 시 정렬이 잘 되어 있는지 테스트")
+    public void searchProductTest1() {
+        // given
+        ProductSearchRequest reqDto = new ProductSearchRequest(
+                1,
+                10,
+                "상품",
+                "DESC",
+                "name",
+                Category.TOP,
+                Category.SubCategory.T_SHIRT
+        );
+
+        // when
+        PageProductResponse resDto = productService.searchProducts(reqDto);
+
+        // then
+        // 이름순 내림차순 정렬 하면 첫번째는 상품015, 10번째는 상품006이 조회되어야 함
+        assertThat(resDto.contents().get(0).id()).isEqualTo(15L);
+        assertThat(resDto.contents().get(0).name()).isEqualTo("상품015");
+        assertThat(resDto.contents().get(1).id()).isEqualTo(14L);
+        assertThat(resDto.contents().get(1).name()).isEqualTo("상품014");
+        assertThat(resDto.contents().get(9).id()).isEqualTo(6L);
+        assertThat(resDto.contents().get(9).name()).isEqualTo("상품006");
+    }
+
+
+    @Test
+    @DisplayName("검색된 상품이 판매중인 상품이 아니라면 검색결과에 포함되지 않는 테스트")
+    public void searchProductTest2() {
+        // given
+        ProductSearchRequest reqDto = new ProductSearchRequest(
+                1,
+                10,
+                "미판매",
+                "ASC",
+                "name",
+                Category.TOP,
+                Category.SubCategory.T_SHIRT
+        );
+        // when
+        PageProductResponse resDto = productService.searchProducts(reqDto);
+
+        assertThat(resDto.contents().stream()
+                .map(ProductResponse::status)
+                .toList()).doesNotContainAnyElementsOf(Arrays.asList(ProductStatus.PENDING, ProductStatus.OFF_SALE));
+        assertThat(resDto.contents()).hasSize(0);
+        assertThat(resDto.totalPage()).isEqualTo(0);
+    }
+
+    @Test
+    @DisplayName("페이지네이션이 작동하는지 확인 테스트")
+    public void searchProductTest3() {
+        // given
+        ProductSearchRequest reqDto = new ProductSearchRequest(
+                3,
+                5,
+                "상품",
+                "ASC",
+                "name",
+                Category.TOP,
+                Category.SubCategory.T_SHIRT
+        );
+
+        // when
+        PageProductResponse resDto = productService.searchProducts(reqDto);
+
+        // then
+        // 17개중 ON_SALE은 15개 이므로 size: 5라면 3페이지 5개여야 함
+        assertThat(resDto.totalPage()).isEqualTo(3);
+        assertThat(resDto.contents()).hasSize(5);
+
+    }
+}

--- a/b2c/src/test/resources/application.yml
+++ b/b2c/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+# H2 메모리 데이터베이스 설정
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    database-platform: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
## 🔘Part 
- B2C 상품 검색 & 상품 단건 조회 테스트코드

## 🔎 작업 내용 
- test 전용 h2 데이터베이스를 사용하여 DB 통합테스트를 위한 의존성 추가 및 설정
- 상품 단건 조회 시 리플렉션을 이용하여 기존 코드를 건드리지 않고 product 생성하는 단위 테스트 작성
- 상품 검색 시 QueryDSL이 의도한데로 동작하여 검색결과를 반환하는지 확인하는 통합 테스트 작성

## 🔧 앞으로의 과제 
- jaccoco 테스트 커버리지 100% 달성

## ➕ 이슈 링크 
- #53
