### PR TITLE
[#25] feat: B2C 연관 추천 상품 조회 기능 추가

### DIFF
--- a/b2c/src/main/java/com/sparta/b2c/product/controller/ProductController.java
+++ b/b2c/src/main/java/com/sparta/b2c/product/controller/ProductController.java
@@ -1,6 +1,7 @@
 package com.sparta.b2c.product.controller;
 
 import com.sparta.b2c.product.dto.request.ProductSearchRequest;
+import com.sparta.b2c.product.dto.request.RelatedProductRetrieveRequest;
 import com.sparta.b2c.product.dto.response.PageProductResponse;
 import com.sparta.b2c.product.dto.response.ProductResponse;
 import com.sparta.b2c.product.service.ProductService;
@@ -40,10 +41,10 @@ public class ProductController {
             @RequestParam(defaultValue = "DEFAULT") Category.SubCategory subCategory
     ) {
 
-        ProductSearchRequest request = new ProductSearchRequest(page, size, keyword, orderBy, sortBy, category, subCategory);
+        ProductSearchRequest reqDto = new ProductSearchRequest(page, size, keyword, orderBy, sortBy, category, subCategory);
 
         // Validation 추가 수동 검증
-        Set<ConstraintViolation<ProductSearchRequest>> violations = validator.validate(request);
+        Set<ConstraintViolation<ProductSearchRequest>> violations = validator.validate(reqDto);
         violations.stream()
                 .map(ConstraintViolation::getMessage)
                 .findFirst()  // 첫 번째 violation만 처리
@@ -53,6 +54,28 @@ public class ProductController {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
-                .body(productService.searchProducts(request));
+                .body(productService.searchProducts(reqDto));
+    }
+
+    @GetMapping("/related-products")
+    public ResponseEntity<PageProductResponse> retrieveRelatedProducts(
+            @RequestParam(defaultValue = "1") int page,
+            @RequestParam(defaultValue = "10") int size,
+            @RequestParam(defaultValue = "DEFAULT") Category.SubCategory subCategory
+    ) {
+        RelatedProductRetrieveRequest reqDto = new RelatedProductRetrieveRequest(page, size, subCategory);
+
+        // Validation 추가 수동 검증
+        Set<ConstraintViolation<RelatedProductRetrieveRequest>> violations = validator.validate(reqDto);
+        violations.stream()
+                .map(ConstraintViolation::getMessage)
+                .findFirst()  // 첫 번째 violation만 처리
+                .ifPresent(message -> {
+                    throw new IllegalArgumentException(message);
+                });
+
+        return ResponseEntity
+                .status(HttpStatus.OK)
+                .body(productService.retrieveRelatedProducts(reqDto));
     }
 }

--- a/b2c/src/main/java/com/sparta/b2c/product/dto/request/RelatedProductRetrieveRequest.java
+++ b/b2c/src/main/java/com/sparta/b2c/product/dto/request/RelatedProductRetrieveRequest.java
@@ -1,0 +1,17 @@
+package com.sparta.b2c.product.dto.request;
+
+import com.sparta.impostor.commerce.backend.domain.product.enums.Category;
+import jakarta.validation.constraints.Max;
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.Pattern;
+
+public record RelatedProductRetrieveRequest (
+        @Min(value = 1, message = "page는 1보다 작을 수 없습니다.")
+        int page,
+
+        @Max(value = 50, message = "size를 50을 넘길 수 없습니다.")
+        int size,
+
+        Category.SubCategory subCategory
+) {
+}

--- a/b2c/src/main/java/com/sparta/b2c/product/service/ProductService.java
+++ b/b2c/src/main/java/com/sparta/b2c/product/service/ProductService.java
@@ -1,6 +1,7 @@
 package com.sparta.b2c.product.service;
 
 import com.sparta.b2c.product.dto.request.ProductSearchRequest;
+import com.sparta.b2c.product.dto.request.RelatedProductRetrieveRequest;
 import com.sparta.b2c.product.dto.response.PageProductResponse;
 import com.sparta.b2c.product.dto.response.ProductResponse;
 import com.sparta.impostor.commerce.backend.common.exception.ForbiddenAccessException;
@@ -41,6 +42,13 @@ public class ProductService {
         Sort sort = Sort.by(direction, reqDto.sortBy());
         Pageable pageable = PageRequest.of(reqDto.page() - 1, reqDto.size(), sort);
         Page<Product> products = productRepository.searchProductsWithFilters(reqDto.keyword(), ProductStatus.ON_SALE, reqDto.category(), reqDto.subCategory(), pageable);
+
+        return PageProductResponse.from(products);
+    }
+
+    public PageProductResponse retrieveRelatedProducts(RelatedProductRetrieveRequest reqDto) {
+        Pageable pageable = PageRequest.of(reqDto.page() - 1, reqDto.size());
+        Page<Product> products = productRepository.retrieveRelatedProducts(ProductStatus.ON_SALE, reqDto.subCategory(), pageable);
 
         return PageProductResponse.from(products);
     }

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/repository/ProductRepositoryQuery.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/repository/ProductRepositoryQuery.java
@@ -11,4 +11,5 @@ import java.util.Optional;
 public interface ProductRepositoryQuery {
 
     Page<Product> searchProductsWithFilters(String keyword, ProductStatus productStatus, Category category, Category.SubCategory subCategory, Pageable pageable);
+    Page<Product> retrieveRelatedProducts(ProductStatus productStatus, Category.SubCategory subCategory, Pageable pageable);
 }


### PR DESCRIPTION

## 🔘Part 
- B2C 연관 상품 추천 조회 기능

## 🔎 작업 내용 
- 사용자에게 관심가질 법한 상품을 10개 추천해주는 기능의 API
- 구체적인 추천 상품을 선정하는 것과 정렬의 기준의 요구사항이 자주 변경 될 수 있으므로 QueryDSL의 조건절과 정렬절을 분리시켜 최대한 유연하게 작성이 가능하도록 고려하며 작성
  - 현재 로직은 **동일한 서브카테고리** 중 **판매량이 높고**, 판매량이 같다면 **낮은 가격 순서대로** 정렬되어 조회되도록 작성됨
- 페이지네이션 적용할 것
- 상품 상태가 `ON_SALE`만 조회되도록 설정함




## 🔧 앞으로의 과제 
- N+1문제가 없는 것 까지는 확인하였으나, 데이터가 많아질 경우를 대비하여 추가적으로 인덱싱처리할 컬럼필드를 고려하여 성능향상 시킬 수 있도록 개선해줘야 함

## ➕ 이슈 링크 
- #25
