### PR TITLE
[FIX] B2C, B2B, Admin API 간 접근 불가하도록 인가 수정

### DIFF
--- a/admin/src/main/java/com/sparta/admin/member/service/AdminMemberAuthService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/AdminMemberAuthService.java
@@ -25,6 +25,7 @@ public class AdminMemberAuthService {
     private final AdminMemberRepository adminMemberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final RedisTemplate<String, MemberSession> redisTemplate;
+    private static final String SESSION_NAME = "ADMIN_SESSION";
 
     public SignupResponse signup(SignupRequest request) {
 
@@ -43,6 +44,7 @@ public class AdminMemberAuthService {
     }
 
     public ResponseCookie login(LoginRequest request) {
+
         String email = request.email();
         String rawPassword = request.password();
 
@@ -54,10 +56,11 @@ public class AdminMemberAuthService {
         }
 
         String sessionId = new StandardSessionIdGenerator().generateSessionId();
-        redisTemplate.opsForValue().set(sessionId, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
+        String sessionKey = SESSION_NAME + ":" + sessionId;
+        redisTemplate.opsForValue().set(sessionKey, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
 
         return ResponseCookie
-                .from("SESSION", sessionId)
+                .from(SESSION_NAME, sessionId)
                 .path("/")
                 .httpOnly(true)
                 .maxAge(1800)

--- a/b2b/src/main/java/com/sparta/b2b/member/service/B2BMemberAuthService.java
+++ b/b2b/src/main/java/com/sparta/b2b/member/service/B2BMemberAuthService.java
@@ -25,6 +25,7 @@ public class B2BMemberAuthService {
     private final B2BMemberRepository b2BMemberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final RedisTemplate<String, MemberSession> redisTemplate;
+    private static final String SESSION_NAME = "B2B_SESSION";
 
     public SignupResponse signup(SignupRequest request) {
 
@@ -56,10 +57,11 @@ public class B2BMemberAuthService {
         }
 
         String sessionId = new StandardSessionIdGenerator().generateSessionId();
-        redisTemplate.opsForValue().set(sessionId, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
+        String sessionKey = SESSION_NAME + ":" + sessionId;
+        redisTemplate.opsForValue().set(sessionKey, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
 
         return ResponseCookie
-                .from("SESSION", sessionId)
+                .from(SESSION_NAME, sessionId)
                 .path("/")
                 .httpOnly(true)
                 .maxAge(1800)

--- a/b2b/src/main/java/com/sparta/b2b/order/controller/OrderController.java
+++ b/b2b/src/main/java/com/sparta/b2b/order/controller/OrderController.java
@@ -7,6 +7,7 @@ import com.sparta.b2b.order.service.OrderService;
 import com.sparta.common.annotation.CheckAuth;
 import com.sparta.common.annotation.LoginMember;
 import com.sparta.common.dto.MemberSession;
+import com.sparta.common.enums.Role;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -20,24 +21,24 @@ public class OrderController {
 
     private final OrderService orderService;
 
-    @CheckAuth
+    @CheckAuth(role = Role.B2B)
     @GetMapping()
     public ResponseEntity<OrderPageResponse> retrieveOrderList(@RequestParam(defaultValue = "1") int page,
                                                                @RequestParam(defaultValue = "10") int size,
                                                                @RequestParam(required = false, defaultValue = "modifiedAt") String sortBy,
                                                                @RequestParam(required = false, defaultValue = "DESC") String orderBy,
-                                                               @LoginMember MemberSession memberSession) {
+                                                               @LoginMember(role = Role.B2B) MemberSession memberSession) {
 
         return ResponseEntity
                 .status(HttpStatus.OK)
                 .body(orderService.retrieveOrderList(page, size, sortBy, orderBy, memberSession.memberId()));
     }
 
-    @CheckAuth
+    @CheckAuth(role = Role.B2B)
     @PatchMapping("/{id}/delivery-status")
     public ResponseEntity<OrderResponse> updateDeliveryStatus(@PathVariable Long id,
                                                               @RequestBody @Valid DeliveryStatusRequest request,
-                                                              @LoginMember MemberSession memberSession) {
+                                                              @LoginMember(role = Role.B2B) MemberSession memberSession) {
 
         return ResponseEntity
                 .status(HttpStatus.OK)

--- a/b2c/src/main/java/com/sparta/b2c/member/service/B2CMemberAuthService.java
+++ b/b2c/src/main/java/com/sparta/b2c/member/service/B2CMemberAuthService.java
@@ -25,6 +25,7 @@ public class B2CMemberAuthService {
     private final B2CMemberRepository b2CMemberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final RedisTemplate<String, MemberSession> redisTemplate;
+    private static final String SESSION_NAME = "B2C_SESSION";
 
     public SignupResponse signup(SignupRequest request) {
 
@@ -55,10 +56,11 @@ public class B2CMemberAuthService {
         }
 
         String sessionId = new StandardSessionIdGenerator().generateSessionId();
-        redisTemplate.opsForValue().set(sessionId, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
+        String sessionKey = SESSION_NAME + ":" + sessionId;
+        redisTemplate.opsForValue().set(sessionKey, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
 
         return ResponseCookie
-                .from("SESSION", sessionId)
+                .from(SESSION_NAME, sessionId)
                 .path("/")
                 .httpOnly(true)
                 .maxAge(1800)

--- a/common/src/main/java/com/sparta/common/annotation/CheckAuth.java
+++ b/common/src/main/java/com/sparta/common/annotation/CheckAuth.java
@@ -1,5 +1,7 @@
 package com.sparta.common.annotation;
 
+import com.sparta.common.enums.Role;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -8,5 +10,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.METHOD)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface CheckAuth {
-
+    Role role();
 }

--- a/common/src/main/java/com/sparta/common/annotation/LoginMember.java
+++ b/common/src/main/java/com/sparta/common/annotation/LoginMember.java
@@ -1,5 +1,7 @@
 package com.sparta.common.annotation;
 
+import com.sparta.common.enums.Role;
+
 import java.lang.annotation.ElementType;
 import java.lang.annotation.Retention;
 import java.lang.annotation.RetentionPolicy;
@@ -8,5 +10,5 @@ import java.lang.annotation.Target;
 @Target(ElementType.PARAMETER)
 @Retention(RetentionPolicy.RUNTIME)
 public @interface LoginMember {
-
+    Role role();
 }

--- a/common/src/main/java/com/sparta/common/enums/Role.java
+++ b/common/src/main/java/com/sparta/common/enums/Role.java
@@ -1,0 +1,7 @@
+package com.sparta.common.enums;
+
+public enum Role {
+    ADMIN,
+    B2B,
+    B2C
+}

--- a/common/src/main/java/com/sparta/common/interceptor/AuthInterceptor.java
+++ b/common/src/main/java/com/sparta/common/interceptor/AuthInterceptor.java
@@ -1,24 +1,27 @@
 package com.sparta.common.interceptor;
 
 import com.sparta.common.annotation.CheckAuth;
-import com.sparta.common.dto.MemberSession;
-import jakarta.servlet.http.Cookie;
+import com.sparta.common.utils.SessionUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 import org.springframework.web.method.HandlerMethod;
 import org.springframework.web.servlet.HandlerInterceptor;
 
-import java.util.Arrays;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class AuthInterceptor implements HandlerInterceptor {
 
-    private final RedisTemplate<String, MemberSession> redisTemplate;
-    private final static String SESSION_COOKIE_NAME = "SESSION";
+    private final SessionUtil sessionUtil;
+    private static final Map<String, String> SESSION_COOKIE_MAP = Map.of(
+            "ADMIN", "ADMIN_SESSION",
+            "B2B", "B2B_SESSION",
+            "B2C", "B2C_SESSION"
+    );
+
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -26,25 +29,15 @@ public class AuthInterceptor implements HandlerInterceptor {
         if (handler instanceof HandlerMethod handlerMethod) {
             CheckAuth checkAuth = handlerMethod.getMethodAnnotation(CheckAuth.class);
             if (checkAuth != null) {
-                String sessionId = getSessionIdFromCookies(request);
+                String role = checkAuth.role().toString();
+                String cookieName = SESSION_COOKIE_MAP.get(role);
 
-                if (sessionId == null || redisTemplate.opsForValue().get(sessionId) == null) {
+                if (cookieName == null || !sessionUtil.isSessionValid(request, cookieName)) {
                     throw new IllegalArgumentException("로그인이 필요합니다.");
                 }
             }
         }
 
         return true;
-    }
-
-    private String getSessionIdFromCookies(HttpServletRequest request) {
-        if (request.getCookies() != null) {
-            return Arrays.stream(request.getCookies())
-                    .filter(cookie -> SESSION_COOKIE_NAME.equals(cookie.getName()))
-                    .map(Cookie::getValue)
-                    .findFirst()
-                    .orElse(null);
-        }
-        return null;
     }
 }

--- a/common/src/main/java/com/sparta/common/resolver/LoginMemberArgumentResolver.java
+++ b/common/src/main/java/com/sparta/common/resolver/LoginMemberArgumentResolver.java
@@ -2,7 +2,7 @@ package com.sparta.common.resolver;
 
 import com.sparta.common.annotation.LoginMember;
 import com.sparta.common.dto.MemberSession;
-import jakarta.servlet.http.Cookie;
+import com.sparta.common.utils.SessionUtil;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
 import org.springframework.core.MethodParameter;
@@ -13,14 +13,20 @@ import org.springframework.web.context.request.NativeWebRequest;
 import org.springframework.web.method.support.HandlerMethodArgumentResolver;
 import org.springframework.web.method.support.ModelAndViewContainer;
 
-import java.util.Arrays;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolver {
 
     private final HttpServletRequest request;
+    private final SessionUtil sessionUtil;
     private final RedisTemplate<String, MemberSession> redisTemplate;
+    private static final Map<String, String> SESSION_COOKIE_MAP = Map.of(
+            "ADMIN", "ADMIN_SESSION",
+            "B2B", "B2B_SESSION",
+            "B2C", "B2C_SESSION"
+    );
 
     @Override
     public boolean supportsParameter(MethodParameter parameter) {
@@ -33,22 +39,16 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
                                   NativeWebRequest webRequest,
                                   WebDataBinderFactory binderFactory) throws Exception {
 
-        String sessionId = getSessionIdFromCookies(request);
+        LoginMember loginMember = parameter.getParameterAnnotation(LoginMember.class);
+        String role = loginMember.role().toString();
+        String cookieName = SESSION_COOKIE_MAP.get(role);
+
+        String sessionId = sessionUtil.getSessionIdFromCookies(request, cookieName);
         if (sessionId != null) {
-            return redisTemplate.opsForValue().get(sessionId);
+            return redisTemplate.opsForValue().get(cookieName + ":" + sessionId);
         }
 
         return null;
     }
 
-    private String getSessionIdFromCookies(HttpServletRequest request) {
-        if (request.getCookies() != null) {
-            return Arrays.stream(request.getCookies())
-                    .filter(cookie -> "SESSION".equals(cookie.getName()))
-                    .map(Cookie::getValue)
-                    .findFirst()
-                    .orElse(null);
-        }
-        return null;
-    }
 }

--- a/common/src/main/java/com/sparta/common/utils/SessionUtil.java
+++ b/common/src/main/java/com/sparta/common/utils/SessionUtil.java
@@ -1,0 +1,34 @@
+package com.sparta.common.utils;
+
+import com.sparta.common.dto.MemberSession;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.stereotype.Component;
+
+import java.util.Arrays;
+
+@Component
+@RequiredArgsConstructor
+public class SessionUtil {
+
+    private final RedisTemplate<String, MemberSession> redisTemplate;
+
+    public boolean isSessionValid(HttpServletRequest request, String cookieName) {
+        String sessionId = getSessionIdFromCookies(request, cookieName);
+        return sessionId != null && redisTemplate.opsForValue().get(cookieName + ":" + sessionId) != null;
+
+    }
+
+    public String getSessionIdFromCookies(HttpServletRequest request, String cookieName) {
+        if (request.getCookies() != null) {
+            return Arrays.stream(request.getCookies())
+                    .filter(cookie -> cookieName.equals(cookie.getName()))
+                    .map(Cookie::getValue)
+                    .findFirst()
+                    .orElse(null);
+        }
+        return null;
+    }
+}

--- a/common/src/main/resources/application-common.yml
+++ b/common/src/main/resources/application-common.yml
@@ -1,9 +1,7 @@
 spring:
   session:
-
     redis:
       flush-mode: on_save
-      namespace: imposter:session
   data:
     redis:
       host: 127.0.0.1


### PR DESCRIPTION
## 🔘Part 
- B2C, B2B, Admin API 간 접근 불가하도록 인가 수정

## 🔎 작업 내용 
- 각 모듈의 사용자가 다른 모듈의 API의 접근하는 경우 인가가 되지 않도록 로직 수정

## 🔧 앞으로의 과제 
- B2B, B2C 회원 상태 변경 시 세션이 삭제되도록 코드 수정
- B2B, B2C 회원 상태 변경 시 로그인이 불가하도록 코드 수정

## ➕ 이슈 링크 
- #64 
