### PR TITLE
[#27] Feat: ADMIN용 상품 조회 구현

### DIFF
--- a/admin/src/main/java/com/sparta/admin/product/controller/ProductController.java
+++ b/admin/src/main/java/com/sparta/admin/product/controller/ProductController.java
@@ -1,0 +1,39 @@
+package com.sparta.admin.product.controller;
+
+import com.sparta.admin.product.dto.request.ProductRequest;
+import com.sparta.admin.product.dto.response.PageProductResponse;
+import com.sparta.admin.product.service.ProductService;
+import com.sparta.impostor.commerce.backend.domain.product.enums.ProductStatus;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/products")
+public class ProductController {
+
+  private final ProductService productService;
+
+  @GetMapping()
+  public ResponseEntity<PageProductResponse> getProducts(
+      @RequestParam(required = false) ProductStatus status,
+      @RequestParam(required = false) int page,
+      @RequestParam(required = false) int size,
+      @RequestParam(required = false) String sortBy,
+      @RequestParam(required = false) String orderBy) {
+
+    ProductRequest reqDto = new ProductRequest(
+        status, page, size, sortBy, orderBy
+    );
+
+    PageProductResponse resDto = productService.getAllProducts(reqDto);
+
+    return ResponseEntity.status(HttpStatus.OK).body(resDto);
+  }
+
+}

--- a/admin/src/main/java/com/sparta/admin/product/dto/request/ProductRequest.java
+++ b/admin/src/main/java/com/sparta/admin/product/dto/request/ProductRequest.java
@@ -1,0 +1,13 @@
+package com.sparta.admin.product.dto.request;
+
+import com.sparta.impostor.commerce.backend.domain.product.enums.ProductStatus;
+
+public record ProductRequest(
+    ProductStatus status,
+    int page,
+    int size,
+    String sortBy,
+    String orderBy
+) {
+
+}

--- a/admin/src/main/java/com/sparta/admin/product/dto/response/PageProductResponse.java
+++ b/admin/src/main/java/com/sparta/admin/product/dto/response/PageProductResponse.java
@@ -1,0 +1,22 @@
+package com.sparta.admin.product.dto.response;
+
+
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import java.util.List;
+import org.springframework.data.domain.Page;
+
+public record PageProductResponse(
+        List<ProductResponse> contents,
+        int page,
+        int size,
+        int totalPage
+) {
+    public static PageProductResponse from(Page<Product> productPage) {
+        return new PageProductResponse(
+                productPage.getContent().stream().map(ProductResponse::from).toList(),
+                productPage.getNumber() + 1,
+                productPage.getSize(),
+                productPage.getTotalPages()
+        );
+    }
+}

--- a/admin/src/main/java/com/sparta/admin/product/dto/response/ProductResponse.java
+++ b/admin/src/main/java/com/sparta/admin/product/dto/response/ProductResponse.java
@@ -1,0 +1,35 @@
+package com.sparta.admin.product.dto.response;
+
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import com.sparta.impostor.commerce.backend.domain.product.enums.Category;
+import com.sparta.impostor.commerce.backend.domain.product.enums.ProductStatus;
+import java.time.LocalDateTime;
+
+public record ProductResponse (
+        Long id,
+        String name,
+        String description,
+        int price,
+        int stockQuantity,
+        ProductStatus status,
+        Category category,
+        Category.SubCategory subCategory,
+        LocalDateTime createdAt,
+        LocalDateTime modifiedAt
+) {
+
+    public static ProductResponse from(Product product) {
+        return new ProductResponse(
+                product.getId(),
+                product.getName(),
+                product.getDescription(),
+                product.getPrice(),
+                product.getStockQuantity(),
+                product.getStatus(),
+                product.getCategory(),
+                product.getSubCategory(),
+                product.getCreatedAt(),
+                product.getModifiedAt()
+        );
+    }
+}

--- a/admin/src/main/java/com/sparta/admin/product/service/ProductService.java
+++ b/admin/src/main/java/com/sparta/admin/product/service/ProductService.java
@@ -1,0 +1,42 @@
+package com.sparta.admin.product.service;
+
+import com.sparta.admin.product.dto.request.ProductRequest;
+import com.sparta.admin.product.dto.response.PageProductResponse;
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import com.sparta.impostor.commerce.backend.domain.product.enums.Category;
+import com.sparta.impostor.commerce.backend.domain.product.enums.Category.SubCategory;
+import com.sparta.impostor.commerce.backend.domain.product.repository.ProductRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class ProductService {
+
+  private final ProductRepository productRepository;
+
+  public PageProductResponse getAllProducts(ProductRequest productRequest) {
+
+    Pageable pageable = PageRequest.of(
+        productRequest.page() - 1,
+        productRequest.size(),
+        productRequest.orderBy().equalsIgnoreCase("asc") ?
+            Sort.by(productRequest.sortBy()).ascending()
+            : Sort.by(productRequest.sortBy()).descending()
+    );
+
+    Page<Product> products = productRepository.searchProductsWithFilters(
+        "",
+        productRequest.status(),
+        Category.DEFAULT,
+        SubCategory.DEFAULT,
+        pageable
+    );
+    return PageProductResponse.from(products);
+
+  }
+}


### PR DESCRIPTION
## 🔘Part 
- Admin의 상품 조회

## 🔎 작업 내용 
- Admin이 B2B 회원의 상품을 조회할 수 있도록 기능을 구현하였습니다.
- 상품 상태 (ON_SALE, OFF_SALE, PENDING)를 기준으로 필터링할 수 있으며,
페이지네이션과 정렬을 지원합니다.

### - 예시 요청 및 응답
- GET /api/admin/products?status=_ON_SALE&page=1&size=10&sortBy=name&orderBy=asc

## 🔧 앞으로의 과제 
- B2B 상품 등록 승인 및 거절 (예정)

## ➕ 이슈 링크 
- #27 
