### PR TITLE
[#18] feat: B2C 주문 목록 조회 기능 구현

### DIFF
--- a/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
@@ -2,7 +2,12 @@ package com.sparta.b2c.order.controller;
 
 import com.sparta.b2c.order.dto.request.OrderRequest;
 import com.sparta.b2c.order.dto.response.OrderResponse;
+import com.sparta.b2c.order.dto.response.PageOrderResponse;
 import com.sparta.b2c.order.service.OrderService;
+import com.sparta.common.annotation.CheckAuth;
+import com.sparta.common.annotation.LoginMember;
+import com.sparta.common.dto.MemberSession;
+import com.sparta.common.enums.Role;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -16,12 +21,25 @@ public class OrderController {
 
     private final OrderService orderService;
 
+    @CheckAuth(role = Role.B2C)
     @PostMapping()
-    public ResponseEntity<OrderResponse>createOrder(@Valid @RequestBody OrderRequest orderRequest) {
+    public ResponseEntity<OrderResponse>createOrder(@Valid @RequestBody OrderRequest orderRequest,
+                                                    @LoginMember(role = Role.B2B) MemberSession memberSession) {
 
         // b2c 로그인 구현 후 로그인 값 변경 예정
-        OrderResponse orderResponse = orderService.createOrder(1L, orderRequest);
+        OrderResponse orderResponse = orderService.createOrder(memberSession.memberId(), orderRequest);
         return ResponseEntity.status(HttpStatus.CREATED).body(orderResponse);
     }
 
+    @CheckAuth(role = Role.B2C)
+    @GetMapping()
+    public ResponseEntity<PageOrderResponse>searchOrderList(@RequestParam(defaultValue = "1") int page,
+                                                            @RequestParam(defaultValue = "10") int size,
+                                                            @RequestParam(required = false, defaultValue = "modifiedAt") String sortBy,
+                                                            @RequestParam(required = false, defaultValue = "DESC") String orderBy,
+                                                            @LoginMember(role = Role.B2C) MemberSession memberSession) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(orderService.searchOrderList(page, size, sortBy, orderBy, memberSession.memberId()));
+
+    }
 }

--- a/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
@@ -32,7 +32,7 @@ public class OrderController {
     }
 
     @CheckAuth(role = Role.B2C)
-    @GetMapping()
+    @GetMapping("/list")
     public ResponseEntity<PageOrderResponse>searchOrderList(@RequestParam(defaultValue = "1") int page,
                                                             @RequestParam(defaultValue = "10") int size,
                                                             @RequestParam(required = false, defaultValue = "modifiedAt") String sortBy,

--- a/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
@@ -24,7 +24,7 @@ public class OrderController {
     @CheckAuth(role = Role.B2C)
     @PostMapping()
     public ResponseEntity<OrderResponse>createOrder(@Valid @RequestBody OrderRequest orderRequest,
-                                                    @LoginMember(role = Role.B2B) MemberSession memberSession) {
+                                                    @LoginMember(role = Role.B2C) MemberSession memberSession) {
 
         // b2c 로그인 구현 후 로그인 값 변경 예정
         OrderResponse orderResponse = orderService.createOrder(memberSession.memberId(), orderRequest);
@@ -32,14 +32,14 @@ public class OrderController {
     }
 
     @CheckAuth(role = Role.B2C)
-    @GetMapping("/list")
+    @GetMapping()
     public ResponseEntity<PageOrderResponse>searchOrderList(@RequestParam(defaultValue = "1") int page,
                                                             @RequestParam(defaultValue = "10") int size,
                                                             @RequestParam(required = false, defaultValue = "modifiedAt") String sortBy,
                                                             @RequestParam(required = false, defaultValue = "DESC") String orderBy,
                                                             @LoginMember(role = Role.B2C) MemberSession memberSession) {
 
-        return ResponseEntity.status(HttpStatus.OK).body(orderService.searchOrderList(page, size, sortBy, orderBy, memberSession.memberId()));
+        return ResponseEntity.status(HttpStatus.OK).body(orderService.searchOrderList(page, size, orderBy, sortBy, memberSession.memberId()));
 
     }
 }

--- a/b2c/src/main/java/com/sparta/b2c/order/dto/response/PageOrderResponse.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/dto/response/PageOrderResponse.java
@@ -1,0 +1,22 @@
+package com.sparta.b2c.order.dto.response;
+
+import com.sparta.impostor.commerce.backend.domain.order.entity.Orders;
+import org.springframework.data.domain.Page;
+
+import java.util.List;
+
+public record PageOrderResponse(
+        List<OrderResponse> orders,
+        int page,
+        int size,
+        int totalPage
+) {
+    public static PageOrderResponse from(Page<Orders> orderPage) {
+        return new PageOrderResponse(
+                orderPage.getContent().stream().map(OrderResponse::from).toList(),
+                orderPage.getNumber() + 1,
+                orderPage.getSize(),
+                orderPage.getTotalPages()
+        );
+    }
+}

--- a/b2c/src/main/java/com/sparta/b2c/order/dto/response/PageOrderResponse.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/dto/response/PageOrderResponse.java
@@ -6,7 +6,7 @@ import org.springframework.data.domain.Page;
 import java.util.List;
 
 public record PageOrderResponse(
-        List<OrderResponse> orders,
+        List<OrderResponse> contents,
         int page,
         int size,
         int totalPage

--- a/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
@@ -2,6 +2,8 @@ package com.sparta.b2c.order.service;
 
 import com.sparta.b2c.order.dto.request.OrderRequest;
 import com.sparta.b2c.order.dto.response.OrderResponse;
+import com.sparta.b2c.order.dto.response.PageOrderResponse;
+import com.sparta.common.dto.MemberSession;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.repository.B2CMemberRepository;
 import com.sparta.impostor.commerce.backend.domain.order.entity.Orders;
@@ -12,6 +14,10 @@ import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
 import com.sparta.impostor.commerce.backend.domain.product.repository.ProductRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -24,9 +30,9 @@ public class OrderService {
     private final B2CMemberRepository b2cMemberRepository;
 
     @Transactional
-    public OrderResponse createOrder(Long b2cMemberId, OrderRequest orderRequest) {
+    public OrderResponse createOrder(Long memberId, OrderRequest orderRequest) {
 
-        B2CMember b2CMember = b2cMemberRepository.findById(b2cMemberId)
+        B2CMember b2CMember = b2cMemberRepository.findById(memberId)
                 .orElseThrow(() -> new EntityNotFoundException("사용자를 찾을 수 없습니다."));
 
         Product product = productRepository.findById(orderRequest.productId())
@@ -55,5 +61,12 @@ public class OrderService {
         orderRepository.save(order);
         return OrderResponse.from(order);
 
+    }
+
+    public PageOrderResponse searchOrderList(int page, int size, String orderBy,String sortBy, Long memberId) {
+        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.fromString(orderBy), sortBy));
+        Page<Orders> orderPage = orderRepository.findAllByMemberId(memberId, pageable);
+
+        return PageOrderResponse.from(orderPage);
     }
 }

--- a/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
@@ -64,7 +64,11 @@ public class OrderService {
     }
 
     public PageOrderResponse searchOrderList(int page, int size, String orderBy,String sortBy, Long memberId) {
-        Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.fromString(orderBy), sortBy));
+        Sort.Direction direction = "ASC".equalsIgnoreCase(orderBy) ? Sort.Direction.ASC : Sort.Direction.DESC;
+        Sort sort = Sort.by(direction, sortBy);
+        Pageable pageable = PageRequest.of(page - 1, size, sort);
+
+
         Page<Orders> orderPage = orderRepository.findAllByB2CMemberId(memberId, pageable);
 
         return PageOrderResponse.from(orderPage);

--- a/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
@@ -65,7 +65,7 @@ public class OrderService {
 
     public PageOrderResponse searchOrderList(int page, int size, String orderBy,String sortBy, Long memberId) {
         Pageable pageable = PageRequest.of(page - 1, size, Sort.by(Sort.Direction.fromString(orderBy), sortBy));
-        Page<Orders> orderPage = orderRepository.findAllByMemberId(memberId, pageable);
+        Page<Orders> orderPage = orderRepository.findAllByB2CMemberId(memberId, pageable);
 
         return PageOrderResponse.from(orderPage);
     }

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/b2cMember/entity/B2CMember.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/b2cMember/entity/B2CMember.java
@@ -35,6 +35,7 @@ public class B2CMember extends Timestamped {
     member.email = email;
     member.password = password;
     member.name = name;
+    member.b2cMemberStatus = B2CMemberStatus.ACTIVE;
     return member;
   }
 

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/repository/OrderRepository.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/repository/OrderRepository.java
@@ -7,5 +7,5 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Orders, Long>, OrderRepositoryQuery {
-    Page<Orders> findAllByMemberId(Long memberId, Pageable pageable);
+    Page<Orders> findAllByB2CMemberId(Long memberId, Pageable pageable);
 }

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/repository/OrderRepository.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/repository/OrderRepository.java
@@ -1,7 +1,11 @@
 package com.sparta.impostor.commerce.backend.domain.order.repository;
 
 import com.sparta.impostor.commerce.backend.domain.order.entity.Orders;
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface OrderRepository extends JpaRepository<Orders, Long>, OrderRepositoryQuery {
+    Page<Orders> findAllByMemberId(Long memberId, Pageable pageable);
 }

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/repository/ProductRepository.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/repository/ProductRepository.java
@@ -5,9 +5,6 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
-import java.time.LocalDateTime;
-import java.util.List;
-
 public interface ProductRepository extends JpaRepository <Product, Long>, ProductRepositoryQuery {
 	Page<Product> findAllByMemberId(Long memberId, Pageable pageable);
 }


### PR DESCRIPTION
## 🔘Part 
-B2C 주문 목록 조회 기능 구현

## 🔎 작업 내용 
- 해당 유저의 모든 주문 리스트와 주문, 배송 상태를 조회 한다.

## 🔧 앞으로의 과제 
- 주문 단건 조회 및 주문 삭제 기능

## ➕ 이슈 링크 
- #18
