### PR TITLE
[Fix] B2B, B2C 회원 상태 변경 시 세션이 삭제 되도록 코드 수정

### DIFF
--- a/admin/src/main/java/com/sparta/admin/member/controller/B2BApprovalController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2BApprovalController.java
@@ -8,11 +8,7 @@ import com.sparta.common.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/admin/src/main/java/com/sparta/admin/member/controller/B2BApprovalController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2BApprovalController.java
@@ -3,6 +3,8 @@ package com.sparta.admin.member.controller;
 import com.sparta.admin.member.dto.request.B2BMemberStatusRequest;
 import com.sparta.admin.member.dto.response.B2BApprovalResponse;
 import com.sparta.admin.member.service.B2BApprovalService;
+import com.sparta.common.annotation.CheckAuth;
+import com.sparta.common.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,6 +22,7 @@ public class B2BApprovalController {
   private final B2BApprovalService b2bApprovalService;
 
   // B2B 회원 권한 요청 승인 또는 거절 (기본 PENDING 상태, 수락 및 거절시 ACTIVE, INACTIVE 상태로 변경)
+  @CheckAuth(role = Role.ADMIN)
   @PatchMapping("/b2b/{memberId}/approve")
   public ResponseEntity<B2BApprovalResponse> approveOrRejectMember(@PathVariable Long memberId,
       @RequestBody B2BMemberStatusRequest request) {

--- a/admin/src/main/java/com/sparta/admin/member/controller/B2BSearchController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2BSearchController.java
@@ -2,6 +2,8 @@ package com.sparta.admin.member.controller;
 
 import com.sparta.admin.member.dto.response.B2BMemberPageResponse;
 import com.sparta.admin.member.service.B2BSearchService;
+import com.sparta.common.annotation.CheckAuth;
+import com.sparta.common.enums.Role;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.enums.B2BMemberStatus;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Sort;
@@ -30,6 +32,7 @@ public class B2BSearchController {
    * @return B2B 회원 목록
    */
 
+  @CheckAuth(role = Role.ADMIN)
   @GetMapping("/b2b-members")
   public ResponseEntity<B2BMemberPageResponse> getB2BMembers(
       @RequestParam(required = false, defaultValue = "1") int page,
@@ -53,6 +56,7 @@ public class B2BSearchController {
    * @return 특정 상태의 B2B 회원 목록
    */
 
+  @CheckAuth(role = Role.ADMIN)
   @GetMapping("/b2b-members/status/{status}")
   public ResponseEntity<B2BMemberPageResponse> getB2BMembersByStatus(
       @PathVariable String status,

--- a/admin/src/main/java/com/sparta/admin/member/controller/B2BSearchController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2BSearchController.java
@@ -6,14 +6,9 @@ import com.sparta.common.annotation.CheckAuth;
 import com.sparta.common.enums.Role;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.enums.B2BMemberStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Sort;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/admin")

--- a/admin/src/main/java/com/sparta/admin/member/controller/B2CSearchController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2CSearchController.java
@@ -3,6 +3,8 @@ package com.sparta.admin.member.controller;
 import com.sparta.admin.member.dto.request.B2CMemberSearchRequest;
 import com.sparta.admin.member.dto.response.B2CMemberPageResponse;
 import com.sparta.admin.member.service.B2CSearchService;
+import com.sparta.common.annotation.CheckAuth;
+import com.sparta.common.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
@@ -20,6 +22,7 @@ public class B2CSearchController {
   private final B2CSearchService b2cSearchService;
 
   // B2C 회원 전체 조회
+  @CheckAuth(role = Role.ADMIN)
   @GetMapping
   public B2CMemberPageResponse getB2CMembers(@ModelAttribute B2CMemberSearchRequest request) {
 

--- a/admin/src/main/java/com/sparta/admin/member/controller/B2CStatusController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2CStatusController.java
@@ -8,11 +8,7 @@ import com.sparta.common.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.PatchMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor

--- a/admin/src/main/java/com/sparta/admin/member/controller/B2CStatusController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2CStatusController.java
@@ -3,6 +3,8 @@ package com.sparta.admin.member.controller;
 import com.sparta.admin.member.dto.request.B2CStatusRequest;
 import com.sparta.admin.member.dto.response.B2CStatusResponse;
 import com.sparta.admin.member.service.B2CStatusService;
+import com.sparta.common.annotation.CheckAuth;
+import com.sparta.common.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,6 +21,7 @@ public class B2CStatusController {
 
   private final B2CStatusService b2cStatusService;
 
+  @CheckAuth(role = Role.ADMIN)
   @PatchMapping("/b2c/{memberId}/update-status")
   public ResponseEntity<B2CStatusResponse> b2CStatusResponseResponseEntity(
       @PathVariable Long memberId,

--- a/admin/src/main/java/com/sparta/admin/member/service/AdminMemberAuthService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/AdminMemberAuthService.java
@@ -3,19 +3,15 @@ package com.sparta.admin.member.service;
 import com.sparta.admin.member.dto.request.LoginRequest;
 import com.sparta.admin.member.dto.request.SignupRequest;
 import com.sparta.admin.member.dto.response.SignupResponse;
-import com.sparta.common.dto.MemberSession;
+import com.sparta.common.utils.SessionUtil;
 import com.sparta.impostor.commerce.backend.domain.adminMember.entity.AdminMember;
 import com.sparta.impostor.commerce.backend.domain.adminMember.repository.AdminMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.util.StandardSessionIdGenerator;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -24,7 +20,7 @@ public class AdminMemberAuthService {
 
     private final AdminMemberRepository adminMemberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
-    private final RedisTemplate<String, MemberSession> redisTemplate;
+    private final SessionUtil sessionUtil;
     private static final String SESSION_NAME = "ADMIN_SESSION";
 
     public SignupResponse signup(SignupRequest request) {
@@ -55,9 +51,7 @@ public class AdminMemberAuthService {
             throw new IllegalArgumentException("패스워드가 일치하지 않습니다.");
         }
 
-        String sessionId = new StandardSessionIdGenerator().generateSessionId();
-        String sessionKey = SESSION_NAME + ":" + sessionId;
-        redisTemplate.opsForValue().set(sessionKey, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
+        String sessionId = sessionUtil.generateSession(SESSION_NAME, member.getId());
 
         return ResponseCookie
                 .from(SESSION_NAME, sessionId)

--- a/admin/src/main/java/com/sparta/admin/member/service/B2BApprovalService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/B2BApprovalService.java
@@ -2,6 +2,7 @@ package com.sparta.admin.member.service;
 
 import com.sparta.admin.member.dto.request.B2BMemberStatusRequest;
 import com.sparta.admin.member.dto.response.B2BApprovalResponse;
+import com.sparta.common.utils.SessionUtil;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.entity.B2BMember;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.enums.B2BMemberStatus;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.repository.B2BMemberRepository;
@@ -15,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class B2BApprovalService {
 
   private final B2BMemberRepository b2bMemberRepository;
+  private final SessionUtil sessionUtil;
+  private static final String SESSION_NAME = "B2B_SESSION";
 
   // 어드민이 B2B 회원 권한 요청 승인하거나 거절할 때, ACTIVE, INACTIVE 로 설정 (기본값 PENDING)
   public B2BApprovalResponse approveOrRejectMember(Long memberId, B2BMemberStatusRequest request) {
@@ -25,6 +28,10 @@ public class B2BApprovalService {
         .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
     B2BMember updatedMember = member.changeStatus(b2bMemberStatus);
+
+    if (updatedMember.getB2BMemberStatus() == B2BMemberStatus.INACTIVE) {
+      sessionUtil.deleteSession(SESSION_NAME, updatedMember.getId());
+    }
 
     return B2BApprovalResponse.from(updatedMember);
   }

--- a/admin/src/main/java/com/sparta/admin/member/service/B2CStatusService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/B2CStatusService.java
@@ -2,6 +2,7 @@ package com.sparta.admin.member.service;
 
 import com.sparta.admin.member.dto.request.B2CStatusRequest;
 import com.sparta.admin.member.dto.response.B2CStatusResponse;
+import com.sparta.common.utils.SessionUtil;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.repository.B2CMemberRepository;
@@ -15,6 +16,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class B2CStatusService {
 
   private final B2CMemberRepository b2cMemberRepository;
+  private final SessionUtil sessionUtil;
+  private static final String SESSION_NAME = "B2C_SESSION";
 
   // B2C 회원 ACTIVE, INACTIVE 로 상태 전환
   public B2CStatusResponse updateB2CStatus(Long memberId, B2CStatusRequest request) {
@@ -25,6 +28,10 @@ public class B2CStatusService {
         .orElseThrow(() -> new IllegalArgumentException("회원이 존재하지 않습니다."));
 
     B2CMember updatedMember = b2cMember.changeStatus(newStatus);
+
+    if (updatedMember.getB2cMemberStatus() == B2CMemberStatus.INACTIVE) {
+      sessionUtil.deleteSession(SESSION_NAME, updatedMember.getId());
+    }
 
     return B2CStatusResponse.from(updatedMember);
   }

--- a/admin/src/main/resources/application.yml
+++ b/admin/src/main/resources/application.yml
@@ -4,3 +4,5 @@ spring:
     include:
       - domain
       - common
+#server:
+#  port: 8080

--- a/b2b/src/main/java/com/sparta/b2b/member/service/B2BMemberAuthService.java
+++ b/b2b/src/main/java/com/sparta/b2b/member/service/B2BMemberAuthService.java
@@ -3,7 +3,7 @@ package com.sparta.b2b.member.service;
 import com.sparta.b2b.member.dto.request.LoginRequest;
 import com.sparta.b2b.member.dto.request.SignupRequest;
 import com.sparta.b2b.member.dto.response.SignupResponse;
-import com.sparta.common.dto.MemberSession;
+import com.sparta.common.utils.SessionUtil;
 import com.sparta.impostor.commerce.backend.common.exception.AuthenticationFailedException;
 import com.sparta.impostor.commerce.backend.common.exception.ForbiddenAccessException;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.entity.B2BMember;
@@ -11,14 +11,10 @@ import com.sparta.impostor.commerce.backend.domain.b2bMember.enums.B2BMemberStat
 import com.sparta.impostor.commerce.backend.domain.b2bMember.repository.B2BMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
-import org.apache.catalina.util.StandardSessionIdGenerator;
-import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.http.ResponseCookie;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.concurrent.TimeUnit;
 
 @Service
 @RequiredArgsConstructor
@@ -27,7 +23,7 @@ public class B2BMemberAuthService {
 
     private final B2BMemberRepository b2BMemberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
-    private final RedisTemplate<String, MemberSession> redisTemplate;
+    private final SessionUtil sessionUtil;
     private static final String SESSION_NAME = "B2B_SESSION";
 
     public SignupResponse signup(SignupRequest request) {
@@ -63,9 +59,7 @@ public class B2BMemberAuthService {
             throw new ForbiddenAccessException("비활성화된 사용자 입니다. 관리자에게 연락해주세요.");
         }
 
-        String sessionId = new StandardSessionIdGenerator().generateSessionId();
-        String sessionKey = SESSION_NAME + ":" + sessionId;
-        redisTemplate.opsForValue().set(sessionKey, new MemberSession(member.getId()), 30L, TimeUnit.MINUTES);
+        String sessionId = sessionUtil.generateSession(SESSION_NAME, member.getId());
 
         return ResponseCookie
                 .from(SESSION_NAME, sessionId)

--- a/b2b/src/main/java/com/sparta/b2b/member/service/B2BMemberAuthService.java
+++ b/b2b/src/main/java/com/sparta/b2b/member/service/B2BMemberAuthService.java
@@ -4,7 +4,10 @@ import com.sparta.b2b.member.dto.request.LoginRequest;
 import com.sparta.b2b.member.dto.request.SignupRequest;
 import com.sparta.b2b.member.dto.response.SignupResponse;
 import com.sparta.common.dto.MemberSession;
+import com.sparta.impostor.commerce.backend.common.exception.AuthenticationFailedException;
+import com.sparta.impostor.commerce.backend.common.exception.ForbiddenAccessException;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.entity.B2BMember;
+import com.sparta.impostor.commerce.backend.domain.b2bMember.enums.B2BMemberStatus;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.repository.B2BMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -53,7 +56,11 @@ public class B2BMemberAuthService {
                 new EntityNotFoundException("회원정보가 존재하지 않습니다."));
 
         if (!passwordEncoder.matches(rawPassword, member.getPassword())) {
-            throw new IllegalArgumentException("패스워드가 일치하지 않습니다.");
+            throw new AuthenticationFailedException("패스워드가 일치하지 않습니다.");
+        }
+
+        if (member.getB2BMemberStatus() == B2BMemberStatus.INACTIVE) {
+            throw new ForbiddenAccessException("비활성화된 사용자 입니다. 관리자에게 연락해주세요.");
         }
 
         String sessionId = new StandardSessionIdGenerator().generateSessionId();

--- a/b2b/src/main/resources/application.yml
+++ b/b2b/src/main/resources/application.yml
@@ -12,3 +12,5 @@ management:
     web:
       exposure:
         include: beans  # beans 엔드포인트를 공개
+#server:
+#  port: 8081

--- a/b2c/src/main/java/com/sparta/b2c/member/service/B2CMemberAuthService.java
+++ b/b2c/src/main/java/com/sparta/b2c/member/service/B2CMemberAuthService.java
@@ -4,7 +4,10 @@ import com.sparta.b2c.member.dto.request.LoginRequest;
 import com.sparta.b2c.member.dto.request.SignupRequest;
 import com.sparta.b2c.member.dto.response.SignupResponse;
 import com.sparta.common.dto.MemberSession;
+import com.sparta.impostor.commerce.backend.common.exception.AuthenticationFailedException;
+import com.sparta.impostor.commerce.backend.common.exception.ForbiddenAccessException;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.repository.B2CMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
@@ -52,7 +55,11 @@ public class B2CMemberAuthService {
                 new EntityNotFoundException("회원정보가 존재하지 않습니다."));
 
         if (!passwordEncoder.matches(rawPassword, member.getPassword())) {
-            throw new IllegalArgumentException("패스워드가 일치하지 않습니다.");
+            throw new AuthenticationFailedException("패스워드가 일치하지 않습니다.");
+        }
+
+        if (member.getB2cMemberStatus() == B2CMemberStatus.INACTIVE) {
+            throw new ForbiddenAccessException("비활성화된 사용자 입니다. 관리자에게 연락해주세요.");
         }
 
         String sessionId = new StandardSessionIdGenerator().generateSessionId();

--- a/b2c/src/main/resources/application.yml
+++ b/b2c/src/main/resources/application.yml
@@ -4,3 +4,5 @@ spring:
     include:
       - domain
       - common
+#server:
+#  port: 8082

--- a/common/src/main/java/com/sparta/common/config/RedisConfig.java
+++ b/common/src/main/java/com/sparta/common/config/RedisConfig.java
@@ -37,4 +37,13 @@ public class RedisConfig {
         template.setValueSerializer(new Jackson2JsonRedisSerializer<>(MemberSession.class));
         return template;
     }
+
+    @Bean
+    public RedisTemplate<String, Object> redisListTemplate() {
+        RedisTemplate<String, Object> template = new RedisTemplate<>();
+        template.setConnectionFactory(redisConnectionFactory());
+        template.setKeySerializer(new StringRedisSerializer());
+        template.setValueSerializer(new Jackson2JsonRedisSerializer<>(String.class));
+        return template;
+    }
 }

--- a/common/src/main/java/com/sparta/common/resolver/LoginMemberArgumentResolver.java
+++ b/common/src/main/java/com/sparta/common/resolver/LoginMemberArgumentResolver.java
@@ -45,7 +45,7 @@ public class LoginMemberArgumentResolver implements HandlerMethodArgumentResolve
 
         String sessionId = sessionUtil.getSessionIdFromCookies(request, cookieName);
         if (sessionId != null) {
-            return redisTemplate.opsForValue().get(cookieName + ":" + sessionId);
+            return redisTemplate.opsForValue().get(sessionId);
         }
 
         return null;

--- a/common/src/main/java/com/sparta/common/utils/SessionUtil.java
+++ b/common/src/main/java/com/sparta/common/utils/SessionUtil.java
@@ -4,20 +4,34 @@ import com.sparta.common.dto.MemberSession;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import lombok.RequiredArgsConstructor;
+import org.apache.catalina.util.StandardSessionIdGenerator;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.stereotype.Component;
 
 import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
 
 @Component
 @RequiredArgsConstructor
 public class SessionUtil {
 
     private final RedisTemplate<String, MemberSession> redisTemplate;
+    private final RedisTemplate<String, Object> redisListTemplate;
+
+    public String generateSession(String sessionName, Long memberId) {
+        String sessionId = new StandardSessionIdGenerator().generateSessionId();
+        String sessionKey = sessionName + ":" + memberId.toString();
+
+        redisListTemplate.opsForList().rightPush(sessionKey, sessionId);
+        redisTemplate.opsForValue().set(sessionId, new MemberSession(memberId), 30L, TimeUnit.MINUTES);
+
+        return sessionId;
+    }
 
     public boolean isSessionValid(HttpServletRequest request, String cookieName) {
         String sessionId = getSessionIdFromCookies(request, cookieName);
-        return sessionId != null && redisTemplate.opsForValue().get(cookieName + ":" + sessionId) != null;
+        return sessionId != null && redisTemplate.opsForValue().get(sessionId) != null;
 
     }
 
@@ -30,5 +44,17 @@ public class SessionUtil {
                     .orElse(null);
         }
         return null;
+    }
+
+    public void deleteSession(String sessionName, Long memberId) {
+        String sessionKey = sessionName + ":" + memberId.toString();
+        List<Object> sessionList = redisListTemplate.opsForList().range(sessionKey, 0, -1);
+
+        if (sessionList != null) {
+            sessionList.stream()
+                    .filter(session -> redisTemplate.opsForValue().get(session) != null)
+                    .forEach(session -> redisTemplate.delete((String) session));
+            redisListTemplate.delete(sessionKey);
+        }
     }
 }


### PR DESCRIPTION
## 🔘Part 
- B2B, B2C 회원 상태 변경 시 세션이 삭제 되도록 코드 수정
- B2B, B2C 회원 상태 변경 시 로그인이 불가하도록 코드 수정

## 🔎 작업 내용 
- Session 생성, 삭제와 관련된 기능을 SessionUtil 클래스로 분류
- 로그인하면 Redis에 세션이 2개 저장됨
  1) key: ADMIN_SESSION:{memberId}, value: ["981E50DB0595BA2FBD180DF5180E4C90"]
  2) key: 981E50DB0595BA2FBD180DF5180E4C90, value: ( memberId: 1 }
- B2B, B2C 권한이 INACTIVE 상태가 되면 위 세션 정보는 모두 삭제됨
- 세션이 삭제되면 클라이언트의 로그인이 풀리게 됨

## 🔧 앞으로의 과제 
- 없음

## ➕ 이슈 링크 
- #68 
