### PR TITLE
[#24] feat: B2C 주문 단건 조회 구현

### DIFF
--- a/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
@@ -23,8 +23,8 @@ public class OrderController {
 
     @CheckAuth(role = Role.B2C)
     @PostMapping()
-    public ResponseEntity<OrderResponse>createOrder(@Valid @RequestBody OrderRequest orderRequest,
-                                                    @LoginMember(role = Role.B2C) MemberSession memberSession) {
+    public ResponseEntity<OrderResponse> createOrder(@Valid @RequestBody OrderRequest orderRequest,
+                                                     @LoginMember(role = Role.B2C) MemberSession memberSession) {
 
         // b2c 로그인 구현 후 로그인 값 변경 예정
         OrderResponse orderResponse = orderService.createOrder(memberSession.memberId(), orderRequest);
@@ -33,13 +33,22 @@ public class OrderController {
 
     @CheckAuth(role = Role.B2C)
     @GetMapping()
-    public ResponseEntity<PageOrderResponse>searchOrderList(@RequestParam(defaultValue = "1") int page,
-                                                            @RequestParam(defaultValue = "10") int size,
-                                                            @RequestParam(required = false, defaultValue = "modifiedAt") String sortBy,
-                                                            @RequestParam(required = false, defaultValue = "DESC") String orderBy,
-                                                            @LoginMember(role = Role.B2C) MemberSession memberSession) {
+    public ResponseEntity<PageOrderResponse> searchOrderList(@RequestParam(defaultValue = "1") int page,
+                                                             @RequestParam(defaultValue = "10") int size,
+                                                             @RequestParam(required = false, defaultValue = "modifiedAt") String sortBy,
+                                                             @RequestParam(required = false, defaultValue = "DESC") String orderBy,
+                                                             @LoginMember(role = Role.B2C) MemberSession memberSession) {
 
         return ResponseEntity.status(HttpStatus.OK).body(orderService.searchOrderList(page, size, orderBy, sortBy, memberSession.memberId()));
 
     }
+
+    @CheckAuth(role = Role.B2C)
+    @GetMapping("{id}")
+    public ResponseEntity<OrderResponse> searchOrder(@PathVariable long id,
+                                                     @LoginMember(role = Role.B2C) MemberSession memberSession) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(orderService.searchOrder(id, memberSession.memberId()));
+    }
+
 }

--- a/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
@@ -4,6 +4,7 @@ import com.sparta.b2c.order.dto.request.OrderRequest;
 import com.sparta.b2c.order.dto.response.OrderResponse;
 import com.sparta.b2c.order.dto.response.PageOrderResponse;
 import com.sparta.common.dto.MemberSession;
+import com.sparta.impostor.commerce.backend.common.exception.ForbiddenAccessException;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.repository.B2CMemberRepository;
 import com.sparta.impostor.commerce.backend.domain.order.entity.Orders;
@@ -72,5 +73,16 @@ public class OrderService {
         Page<Orders> orderPage = orderRepository.findAllByB2CMemberId(memberId, pageable);
 
         return PageOrderResponse.from(orderPage);
+    }
+
+    public OrderResponse searchOrder(long id, Long memberId) {
+        Orders orders = orderRepository.findById(id)
+                .orElseThrow(()-> new EntityNotFoundException("해당 주문을 찾지 못했습니다."));
+
+        if(!orders.getB2CMember().getId().equals(memberId)) {
+            throw new ForbiddenAccessException("본인의 주문만 열람할 수 있습니다.");
+        }
+
+        return OrderResponse.from(orders);
     }
 }


### PR DESCRIPTION
## 🔘Part 
-B2C 주문 단건 조회 구현

## 🔎 작업 내용 
- 단건 주문의 내용을 상세히 조회한다.

## 🔧 앞으로의 과제 
- 주문 취소 기능 구현

## ➕ 이슈 링크 
- #24
