### PR TITLE
[#28] Feat: B2B 상품 등록 승인 및 거절

### DIFF
--- a/admin/src/main/java/com/sparta/admin/product/controller/ProductApprovalController.java
+++ b/admin/src/main/java/com/sparta/admin/product/controller/ProductApprovalController.java
@@ -1,0 +1,33 @@
+package com.sparta.admin.product.controller;
+
+import com.sparta.admin.product.dto.request.ProductApprovalRequest;
+import com.sparta.admin.product.dto.response.ProductApprovalResponse;
+import com.sparta.admin.product.service.ProductApprovalService;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/products/approval")
+public class ProductApprovalController {
+
+  private final ProductApprovalService productApprovalService;
+
+
+  // 상품 등록 승인 및 거절
+  @PatchMapping("/{productId}")
+  public ResponseEntity<ProductApprovalResponse> approveProduct(@PathVariable Long productId,
+      @RequestBody ProductApprovalRequest request) {
+
+    return ResponseEntity
+        .status(HttpStatus.OK)
+        .body(productApprovalService.approveProduct(productId, request));
+  }
+}
+

--- a/admin/src/main/java/com/sparta/admin/product/dto/request/ProductApprovalRequest.java
+++ b/admin/src/main/java/com/sparta/admin/product/dto/request/ProductApprovalRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.admin.product.dto.request;
+
+import com.sparta.impostor.commerce.backend.domain.product.enums.ProductStatus;
+
+public record ProductApprovalRequest(
+    ProductStatus status
+) {
+
+}

--- a/admin/src/main/java/com/sparta/admin/product/dto/response/ProductApprovalResponse.java
+++ b/admin/src/main/java/com/sparta/admin/product/dto/response/ProductApprovalResponse.java
@@ -1,0 +1,18 @@
+package com.sparta.admin.product.dto.response;
+
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import com.sparta.impostor.commerce.backend.domain.product.enums.ProductStatus;
+import java.time.LocalDateTime;
+
+public record ProductApprovalResponse(
+    ProductStatus status,
+    LocalDateTime modifiedAt
+) {
+
+  public static ProductApprovalResponse from(Product product) {
+    return new ProductApprovalResponse(
+        product.getStatus(),
+        product.getModifiedAt()
+    );
+  }
+}

--- a/admin/src/main/java/com/sparta/admin/product/service/ProductApprovalService.java
+++ b/admin/src/main/java/com/sparta/admin/product/service/ProductApprovalService.java
@@ -1,0 +1,33 @@
+package com.sparta.admin.product.service;
+
+import com.sparta.admin.product.dto.request.ProductApprovalRequest;
+import com.sparta.admin.product.dto.response.ProductApprovalResponse;
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
+import com.sparta.impostor.commerce.backend.domain.product.enums.ProductStatus;
+import com.sparta.impostor.commerce.backend.domain.product.repository.ProductRepository;
+import jakarta.transaction.Transactional;
+import org.springframework.stereotype.Service;
+
+@Service
+@Transactional
+public class ProductApprovalService {
+
+  private final ProductRepository productRepository;
+
+  public ProductApprovalService(ProductRepository productRepository) {
+    this.productRepository = productRepository;
+  }
+
+  // 상품 등록 승인 처리
+  public ProductApprovalResponse approveProduct(Long productId, ProductApprovalRequest request) {
+
+    ProductStatus productStatus = request.status();
+
+    Product product = productRepository.findById(productId)
+        .orElseThrow(() -> new IllegalArgumentException("상품을 찾을 수 없습니다."));
+
+    Product updatedProduct = product.changeStatus(productStatus);
+
+    return ProductApprovalResponse.from(updatedProduct);
+  }
+}

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/entity/Product.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/entity/Product.java
@@ -58,4 +58,7 @@ public class Product extends Timestamped {
         return new Product(name, description, stockQuantity, price, status, category, subCategory, member);
     }
 
+  public Product changeStatus(ProductStatus productStatus) {
+    return this;
+  }
 }


### PR DESCRIPTION
## 🔘Part 
- B2B 상품 등록 승인 및 거절

## 🔎 작업 내용 
-  B2B 회원이 상품을 등록할 때, 관리자(ADMIN)가 승인하거나 거절할 수 있는 기능입니다.
-  status: ON_SALE, OFF_SALE
-  승인 시 ON_SALE, 거절시 OFF_SALE로 상태 변경.
-  PATCH /api/admin/products/approval/{productId} 엔드포인트에서 처리됩니다.
-  요청 시 상품의 상태 값이 유효하지 않으면 예외가 발생합니다.

## 🔧 앞으로의 과제 
- NONE (쨔스!)

## ➕ 이슈 링크 
- #28 
