### PR TITLE
[#26] feat: B2C 주문 환불 요청 기능 구현

### DIFF
--- a/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/controller/OrderController.java
@@ -1,6 +1,7 @@
 package com.sparta.b2c.order.controller;
 
 import com.sparta.b2c.order.dto.request.OrderRequest;
+import com.sparta.b2c.order.dto.request.OrderStatusRequest;
 import com.sparta.b2c.order.dto.response.OrderResponse;
 import com.sparta.b2c.order.dto.response.PageOrderResponse;
 import com.sparta.b2c.order.service.OrderService;
@@ -51,4 +52,12 @@ public class OrderController {
         return ResponseEntity.status(HttpStatus.OK).body(orderService.searchOrder(id, memberSession.memberId()));
     }
 
+    @CheckAuth(role = Role.B2C)
+    @PatchMapping("{id}/order-status")
+    public ResponseEntity<OrderResponse> refundOrder(@PathVariable long id,
+                                                     @Valid @RequestBody OrderStatusRequest request,
+                                                     @LoginMember(role = Role.B2C) MemberSession memberSession) {
+
+        return ResponseEntity.status(HttpStatus.OK).body(orderService.refundOrder(id, request, memberSession.memberId()));
+    }
 }

--- a/b2c/src/main/java/com/sparta/b2c/order/dto/request/OrderStatusRequest.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/dto/request/OrderStatusRequest.java
@@ -1,0 +1,9 @@
+package com.sparta.b2c.order.dto.request;
+
+import jakarta.validation.constraints.NotNull;
+
+public record OrderStatusRequest(
+        @NotNull
+        String orderStatus  // REFUND_REQUEST로 변환 요청
+) {
+}

--- a/b2c/src/main/java/com/sparta/b2c/order/dto/response/OrderResponse.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/dto/response/OrderResponse.java
@@ -11,7 +11,7 @@ public record OrderResponse(
         String name,
         int quantity,
         Long totalPrice,
-        OrderStatus status,
+        OrderStatus orderStatus,
         DeliveryStatus deliveryStatus,
         String trackingNumber,
         LocalDateTime createdAt,

--- a/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
+++ b/b2c/src/main/java/com/sparta/b2c/order/service/OrderService.java
@@ -1,6 +1,7 @@
 package com.sparta.b2c.order.service;
 
 import com.sparta.b2c.order.dto.request.OrderRequest;
+import com.sparta.b2c.order.dto.request.OrderStatusRequest;
 import com.sparta.b2c.order.dto.response.OrderResponse;
 import com.sparta.b2c.order.dto.response.PageOrderResponse;
 import com.sparta.common.dto.MemberSession;
@@ -85,4 +86,25 @@ public class OrderService {
 
         return OrderResponse.from(orders);
     }
+
+    @Transactional
+    public OrderResponse refundOrder(long id, OrderStatusRequest request, Long memberId) {
+
+        String orderStatus = request.orderStatus();
+
+        Orders orders = orderRepository.findById(id)
+                .orElseThrow(()-> new EntityNotFoundException("해당 주문을 찾지 못했습니다."));
+
+        if(!orders.getB2CMember().getId().equals(memberId)) {
+            throw new ForbiddenAccessException("본인의 주문만 환불 요청 할 수 있습니다.");
+        }
+
+        if (!OrderStatus.REFUND_REQUEST.name().equals(orderStatus)) {
+            throw new IllegalArgumentException("REFUND_REQUEST가 아닌 다른 값으로 변경할 권한이 없습니다.");
+        }
+
+        orders.updateOrderStatus(OrderStatus.REFUND_REQUEST);
+        return OrderResponse.from(orders);
+    }
+
 }

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/entity/Orders.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/order/entity/Orders.java
@@ -57,6 +57,11 @@ public class Orders extends Timestamped {
         return this;
     }
 
+    public Orders updateOrderStatus(OrderStatus orderStatus) {
+        this.orderStatus = orderStatus;
+        return this;
+    }
+
     private Orders(String name, int quantity, Long totalPrice, OrderStatus orderStatus, DeliveryStatus deliveryStatus, String trackingNumber, Product product, B2CMember b2CMember, Long b2BMemberId) {
         this.name = name;
         this.quantity = quantity;


### PR DESCRIPTION
## 🔘Part 
-B2C 주문 환불 요청 기능 구현

## 🔎 작업 내용 
- 주문 상태를 REFUND_REQUEST로 변경하고 수정일을 갱신한다.
구매자가 REFUND_REQUEST 요청은 할 수 있지만 CONFIRMED, REFUNDED 등 으로 직접 변경하는 것은 적절하지 않기 때문에
다른 값으로 요청 시 예외처리 한다.

- [EntityNotFoundException] : 존재하지 않는 주문의 id를 입력하면 EntityNotFoundException이 발생한다.
[ForbiddenAccessException] : 주문내역의 B2CMemberId와 로그인한 유저의 id가 일치하지 않으면 ForbiddenAccessException이 발생한다.
[IllegalArgumentException] : 요청 값이 REFUND_REQUEST가 아닌 다른 값을 요청하면 IllegalArgumentException이 발생한다.

## 🔧 앞으로의 과제 
- 프로젝트 고도화 할 내용에 대해 공부하기

## ➕ 이슈 링크 
- #26
