### PR TITLE
[TEST] Admin, B2B, B2C 회원가입, 로그인 테스트 코드

### DIFF
--- a/admin/src/main/java/com/sparta/admin/member/service/AdminMemberAuthService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/AdminMemberAuthService.java
@@ -4,6 +4,7 @@ import com.sparta.admin.member.dto.request.LoginRequest;
 import com.sparta.admin.member.dto.request.SignupRequest;
 import com.sparta.admin.member.dto.response.SignupResponse;
 import com.sparta.common.service.SessionService;
+import com.sparta.impostor.commerce.backend.common.exception.AuthenticationFailedException;
 import com.sparta.impostor.commerce.backend.domain.adminMember.entity.AdminMember;
 import com.sparta.impostor.commerce.backend.domain.adminMember.repository.AdminMemberRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -48,7 +49,7 @@ public class AdminMemberAuthService {
                 new EntityNotFoundException("회원정보가 존재하지 않습니다."));
 
         if (!passwordEncoder.matches(rawPassword, member.getPassword())) {
-            throw new IllegalArgumentException("패스워드가 일치하지 않습니다.");
+            throw new AuthenticationFailedException("패스워드가 일치하지 않습니다.");
         }
 
         String sessionId = sessionService.generateSession(SESSION_NAME, member.getId());

--- a/admin/src/test/java/com/sparta/admin/AdminMemberAuthServiceTest.java
+++ b/admin/src/test/java/com/sparta/admin/AdminMemberAuthServiceTest.java
@@ -1,0 +1,166 @@
+package com.sparta.admin;
+
+import com.sparta.admin.member.dto.request.LoginRequest;
+import com.sparta.admin.member.dto.request.SignupRequest;
+import com.sparta.admin.member.dto.response.SignupResponse;
+import com.sparta.admin.member.service.AdminMemberAuthService;
+import com.sparta.common.service.SessionService;
+import com.sparta.impostor.commerce.backend.common.exception.AuthenticationFailedException;
+import com.sparta.impostor.commerce.backend.domain.adminMember.entity.AdminMember;
+import com.sparta.impostor.commerce.backend.domain.adminMember.repository.AdminMemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+
+@ExtendWith(MockitoExtension.class)
+public class AdminMemberAuthServiceTest {
+
+    @Mock
+    private AdminMemberRepository adminMemberRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private SessionService sessionService;
+
+    private AdminMemberAuthService adminMemberAuthService;
+
+    @BeforeEach
+    public void setUpTest() {
+        adminMemberAuthService = new AdminMemberAuthService(adminMemberRepository, passwordEncoder, sessionService);
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signUpSuccessTest() {
+
+        Mockito.when(adminMemberRepository.save(Mockito.any(AdminMember.class)))
+                .then(returnsFirstArg());
+
+        SignupResponse signupResponse = adminMemberAuthService.signup(new SignupRequest("admin@example.com", "123456789", "홍길동"));
+
+        Assertions.assertEquals(signupResponse.email(), "admin@example.com");
+        Assertions.assertEquals(signupResponse.name(), "홍길동");
+
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 기가입자인 경우")
+    void signupFailureTest() {
+
+        // Given
+        String email = "admin@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+
+        AdminMember existingMember = AdminMember.createMember(email, password, name);
+
+        Mockito.when(adminMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+
+        // When
+        SignupRequest signupRequest = new SignupRequest(email, password, name);
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class, () -> adminMemberAuthService.signup(signupRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("이미 가입한 회원입니다.", exception.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void loginSuccess() {
+
+        // Given
+        String email = "admin@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+        String sessionId = "generated-session-id";
+
+        AdminMember existingMember = AdminMember.createMember(email, password, name);
+
+        Mockito.when(adminMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+        Mockito.when(passwordEncoder.matches(password, existingMember.getPassword()))
+                .thenReturn(true);
+        Mockito.when(sessionService.generateSession(Mockito.eq("ADMIN_SESSION"), Mockito.any()))
+                .thenReturn(sessionId);
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        Cookie cookie = adminMemberAuthService.login(loginRequest);
+
+        // Then
+        Assertions.assertNotNull(cookie);
+        Assertions.assertEquals("ADMIN_SESSION", cookie.getName());
+        Assertions.assertEquals(sessionId, cookie.getValue());
+        Assertions.assertEquals("/", cookie.getPath());
+        Assertions.assertTrue(cookie.isHttpOnly());
+        Assertions.assertEquals(1800, cookie.getMaxAge());
+
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 패스워드가 일치하지 않는 경우")
+    void loginFailsPasswordDoesNotMatch() {
+
+        // Given
+        String email = "admin@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+
+        AdminMember existingMember = AdminMember.createMember(email, password, name);
+
+        Mockito.when(adminMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+        Mockito.when(passwordEncoder.matches("wrongPassword", existingMember.getPassword()))
+                .thenReturn(false);
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, "wrongPassword");
+        AuthenticationFailedException exception = Assertions.assertThrows(
+                AuthenticationFailedException.class, () -> adminMemberAuthService.login(loginRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("패스워드가 일치하지 않습니다.", exception.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 회원정보가 존재하지 않는 경우")
+    void loginFailsForNonexistentMember() {
+
+        // Given
+        String email = "admin@example.com";
+        String password = "123456789";
+
+        Mockito.when(adminMemberRepository.findByEmail(email))
+                .thenReturn(Optional.empty());
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        EntityNotFoundException exception = Assertions.assertThrows(
+                EntityNotFoundException.class, () -> adminMemberAuthService.login(loginRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("회원정보가 존재하지 않습니다.", exception.getMessage());
+
+    }
+}

--- a/b2b/src/main/java/com/sparta/b2b/member/controller/B2BMemberController.java
+++ b/b2b/src/main/java/com/sparta/b2b/member/controller/B2BMemberController.java
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class B2BMemberController {
 
-    private final B2BMemberAuthService b2BMemberAuthService;
+    private final B2BMemberAuthService b2bMemberAuthService;
 
     @PostMapping("/signup")
     public ResponseEntity<SignupResponse> signup(@RequestBody @Valid SignupRequest request) {
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(b2BMemberAuthService.signup(request));
+                .body(b2bMemberAuthService.signup(request));
 
     }
 
@@ -38,7 +38,7 @@ public class B2BMemberController {
     @PostMapping("/login")
     public ResponseEntity<Cookie> login(@RequestBody @Valid LoginRequest request, HttpServletResponse httpResponse) {
 
-        Cookie cookie = b2BMemberAuthService.login(request);
+        Cookie cookie = b2bMemberAuthService.login(request);
         httpResponse.addCookie(cookie);
 
         return ResponseEntity

--- a/b2b/src/main/java/com/sparta/b2b/member/service/B2BMemberAuthService.java
+++ b/b2b/src/main/java/com/sparta/b2b/member/service/B2BMemberAuthService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class B2BMemberAuthService {
 
-    private final B2BMemberRepository b2BMemberRepository;
+    private final B2BMemberRepository b2bMemberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final SessionService sessionService;
     private static final String SESSION_NAME = "B2B_SESSION";
@@ -32,12 +32,12 @@ public class B2BMemberAuthService {
         String password = passwordEncoder.encode(request.password());
         String name = request.name();
 
-        if (b2BMemberRepository.findByEmail(email).isPresent()) {
+        if (b2bMemberRepository.findByEmail(email).isPresent()) {
             throw new IllegalArgumentException("이미 가입한 회원입니다.");
         }
 
         B2BMember createMember = B2BMember.createMember(email, password, name);
-        b2BMemberRepository.save(createMember);
+        b2bMemberRepository.save(createMember);
 
         return SignupResponse.from(createMember);
 
@@ -48,7 +48,7 @@ public class B2BMemberAuthService {
         String email = request.email();
         String rawPassword = request.password();
 
-        B2BMember member = b2BMemberRepository.findByEmail(email).orElseThrow(() ->
+        B2BMember member = b2bMemberRepository.findByEmail(email).orElseThrow(() ->
                 new EntityNotFoundException("회원정보가 존재하지 않습니다."));
 
         if (!passwordEncoder.matches(rawPassword, member.getPassword())) {

--- a/b2b/src/test/java/com/sparta/b2b/B2BMemberAuthServiceTest.java
+++ b/b2b/src/test/java/com/sparta/b2b/B2BMemberAuthServiceTest.java
@@ -1,0 +1,166 @@
+package com.sparta.b2b;
+
+import com.sparta.b2b.member.dto.request.LoginRequest;
+import com.sparta.b2b.member.dto.request.SignupRequest;
+import com.sparta.b2b.member.dto.response.SignupResponse;
+import com.sparta.b2b.member.service.B2BMemberAuthService;
+import com.sparta.common.service.SessionService;
+import com.sparta.impostor.commerce.backend.common.exception.AuthenticationFailedException;
+import com.sparta.impostor.commerce.backend.domain.b2bMember.entity.B2BMember;
+import com.sparta.impostor.commerce.backend.domain.b2bMember.repository.B2BMemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+
+@ExtendWith(MockitoExtension.class)
+public class B2BMemberAuthServiceTest {
+
+    @Mock
+    private B2BMemberRepository b2bMemberRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private SessionService sessionService;
+
+    private B2BMemberAuthService b2bMemberAuthService;
+
+    @BeforeEach
+    public void setUpTest() {
+        b2bMemberAuthService = new B2BMemberAuthService(b2bMemberRepository, passwordEncoder, sessionService);
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signUpSuccessTest() {
+
+        Mockito.when(b2bMemberRepository.save(Mockito.any(B2BMember.class)))
+                .then(returnsFirstArg());
+
+        SignupResponse signupResponse = b2bMemberAuthService.signup(new SignupRequest("b2b@example.com", "123456789", "홍길동"));
+
+        Assertions.assertEquals(signupResponse.email(), "b2b@example.com");
+        Assertions.assertEquals(signupResponse.name(), "홍길동");
+
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 기가입자인 경우")
+    void signupFailureTest() {
+
+        // Given
+        String email = "b2b@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+
+        B2BMember existingMember = B2BMember.createMember(email, password, name);
+
+        Mockito.when(b2bMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+
+        // When
+        SignupRequest signupRequest = new SignupRequest(email, password, name);
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class, () -> b2bMemberAuthService.signup(signupRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("이미 가입한 회원입니다.", exception.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void loginSuccess() {
+
+        // Given
+        String email = "b2b@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+        String sessionId = "generated-session-id";
+
+        B2BMember existingMember = B2BMember.createMember(email, password, name);
+
+        Mockito.when(b2bMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+        Mockito.when(passwordEncoder.matches(password, existingMember.getPassword()))
+                .thenReturn(true);
+        Mockito.when(sessionService.generateSession(Mockito.eq("B2B_SESSION"), Mockito.any()))
+                .thenReturn(sessionId);
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        Cookie cookie = b2bMemberAuthService.login(loginRequest);
+
+        // Then
+        Assertions.assertNotNull(cookie);
+        Assertions.assertEquals("B2B_SESSION", cookie.getName());
+        Assertions.assertEquals(sessionId, cookie.getValue());
+        Assertions.assertEquals("/", cookie.getPath());
+        Assertions.assertTrue(cookie.isHttpOnly());
+        Assertions.assertEquals(1800, cookie.getMaxAge());
+
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 패스워드가 일치하지 않는 경우")
+    void loginFailsPasswordDoesNotMatch() {
+
+        // Given
+        String email = "b2b@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+
+        B2BMember existingMember = B2BMember.createMember(email, password, name);
+
+        Mockito.when(b2bMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+        Mockito.when(passwordEncoder.matches("wrongPassword", existingMember.getPassword()))
+                .thenReturn(false);
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, "wrongPassword");
+        AuthenticationFailedException exception = Assertions.assertThrows(
+                AuthenticationFailedException.class, () -> b2bMemberAuthService.login(loginRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("패스워드가 일치하지 않습니다.", exception.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 회원정보가 존재하지 않는 경우")
+    void loginFailsForNonexistentMember() {
+
+        // Given
+        String email = "b2b@example.com";
+        String password = "123456789";
+
+        Mockito.when(b2bMemberRepository.findByEmail(email))
+                .thenReturn(Optional.empty());
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        EntityNotFoundException exception = Assertions.assertThrows(
+                EntityNotFoundException.class, () -> b2bMemberAuthService.login(loginRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("회원정보가 존재하지 않습니다.", exception.getMessage());
+
+    }
+}

--- a/b2c/src/main/java/com/sparta/b2c/member/controller/B2CMemberController.java
+++ b/b2c/src/main/java/com/sparta/b2c/member/controller/B2CMemberController.java
@@ -22,14 +22,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequiredArgsConstructor
 public class B2CMemberController {
 
-    private final B2CMemberAuthService b2CMemberAuthService;
+    private final B2CMemberAuthService b2cMemberAuthService;
 
     @PostMapping("/signup")
     public ResponseEntity<SignupResponse> signup(@RequestBody @Valid SignupRequest request) {
 
         return ResponseEntity
                 .status(HttpStatus.CREATED)
-                .body(b2CMemberAuthService.signup(request));
+                .body(b2cMemberAuthService.signup(request));
 
     }
 
@@ -37,7 +37,7 @@ public class B2CMemberController {
     @PostMapping("/login")
     public ResponseEntity<Cookie> login(@RequestBody @Valid LoginRequest request, HttpServletResponse httpResponse) {
 
-        Cookie cookie = b2CMemberAuthService.login(request);
+        Cookie cookie = b2cMemberAuthService.login(request);
         httpResponse.addCookie(cookie);
 
         return ResponseEntity

--- a/b2c/src/main/java/com/sparta/b2c/member/service/B2CMemberAuthService.java
+++ b/b2c/src/main/java/com/sparta/b2c/member/service/B2CMemberAuthService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 public class B2CMemberAuthService {
 
-    private final B2CMemberRepository b2CMemberRepository;
+    private final B2CMemberRepository b2cMemberRepository;
     private final BCryptPasswordEncoder passwordEncoder;
     private final SessionService sessionService;
     private static final String SESSION_NAME = "B2C_SESSION";
@@ -32,12 +32,12 @@ public class B2CMemberAuthService {
         String password = passwordEncoder.encode(request.password());
         String name = request.name();
 
-        if (b2CMemberRepository.findByEmail(email).isPresent()) {
+        if (b2cMemberRepository.findByEmail(email).isPresent()) {
             throw new IllegalArgumentException("이미 가입한 회원입니다.");
         }
 
         B2CMember createMember = B2CMember.createMember(email, password, name);
-        b2CMemberRepository.save(createMember);
+        b2cMemberRepository.save(createMember);
 
         return SignupResponse.from(createMember);
     }
@@ -47,7 +47,7 @@ public class B2CMemberAuthService {
         String email = request.email();
         String rawPassword = request.password();
 
-        B2CMember member = b2CMemberRepository.findByEmail(email).orElseThrow(() ->
+        B2CMember member = b2cMemberRepository.findByEmail(email).orElseThrow(() ->
                 new EntityNotFoundException("회원정보가 존재하지 않습니다."));
 
         if (!passwordEncoder.matches(rawPassword, member.getPassword())) {

--- a/b2c/src/test/java/com/sparta/b2c/B2CMemberAuthServiceTest.java
+++ b/b2c/src/test/java/com/sparta/b2c/B2CMemberAuthServiceTest.java
@@ -1,0 +1,166 @@
+package com.sparta.b2c;
+
+import com.sparta.b2c.member.dto.request.LoginRequest;
+import com.sparta.b2c.member.dto.request.SignupRequest;
+import com.sparta.b2c.member.dto.response.SignupResponse;
+import com.sparta.b2c.member.service.B2CMemberAuthService;
+import com.sparta.common.service.SessionService;
+import com.sparta.impostor.commerce.backend.common.exception.AuthenticationFailedException;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.repository.B2CMemberRepository;
+import jakarta.persistence.EntityNotFoundException;
+import jakarta.servlet.http.Cookie;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+import java.util.Optional;
+
+import static org.mockito.AdditionalAnswers.returnsFirstArg;
+
+@ExtendWith(MockitoExtension.class)
+public class B2CMemberAuthServiceTest {
+
+    @Mock
+    private B2CMemberRepository b2cMemberRepository;
+
+    @Mock
+    private BCryptPasswordEncoder passwordEncoder;
+
+    @Mock
+    private SessionService sessionService;
+
+    private B2CMemberAuthService b2cMemberAuthService;
+
+    @BeforeEach
+    public void setUpTest() {
+        b2cMemberAuthService = new B2CMemberAuthService(b2cMemberRepository, passwordEncoder, sessionService);
+    }
+
+    @Test
+    @DisplayName("회원가입 성공")
+    void signUpSuccessTest() {
+
+        Mockito.when(b2cMemberRepository.save(Mockito.any(B2CMember.class)))
+                .then(returnsFirstArg());
+
+        SignupResponse signupResponse = b2cMemberAuthService.signup(new SignupRequest("b2c@example.com", "123456789", "홍길동"));
+
+        Assertions.assertEquals(signupResponse.email(), "b2c@example.com");
+        Assertions.assertEquals(signupResponse.name(), "홍길동");
+
+    }
+
+    @Test
+    @DisplayName("회원가입 실패 - 기가입자인 경우")
+    void signupFailureTest() {
+
+        // Given
+        String email = "b2c@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+
+        B2CMember existingMember = B2CMember.createMember(email, password, name);
+
+        Mockito.when(b2cMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+
+        // When
+        SignupRequest signupRequest = new SignupRequest(email, password, name);
+        IllegalArgumentException exception = Assertions.assertThrows(
+                IllegalArgumentException.class, () -> b2cMemberAuthService.signup(signupRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("이미 가입한 회원입니다.", exception.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("로그인 성공")
+    void loginSuccess() {
+
+        // Given
+        String email = "b2c@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+        String sessionId = "generated-session-id";
+
+        B2CMember existingMember = B2CMember.createMember(email, password, name);
+
+        Mockito.when(b2cMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+        Mockito.when(passwordEncoder.matches(password, existingMember.getPassword()))
+                .thenReturn(true);
+        Mockito.when(sessionService.generateSession(Mockito.eq("B2C_SESSION"), Mockito.any()))
+                .thenReturn(sessionId);
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        Cookie cookie = b2cMemberAuthService.login(loginRequest);
+
+        // Then
+        Assertions.assertNotNull(cookie);
+        Assertions.assertEquals("B2C_SESSION", cookie.getName());
+        Assertions.assertEquals(sessionId, cookie.getValue());
+        Assertions.assertEquals("/", cookie.getPath());
+        Assertions.assertTrue(cookie.isHttpOnly());
+        Assertions.assertEquals(1800, cookie.getMaxAge());
+
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 패스워드가 일치하지 않는 경우")
+    void loginFailsPasswordDoesNotMatch() {
+
+        // Given
+        String email = "b2c@example.com";
+        String password = "123456789";
+        String name = "홍길동";
+
+        B2CMember existingMember = B2CMember.createMember(email, password, name);
+
+        Mockito.when(b2cMemberRepository.findByEmail(email))
+                .thenReturn(Optional.of(existingMember));
+        Mockito.when(passwordEncoder.matches("wrongPassword", existingMember.getPassword()))
+                .thenReturn(false);
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, "wrongPassword");
+        AuthenticationFailedException exception = Assertions.assertThrows(
+                AuthenticationFailedException.class, () -> b2cMemberAuthService.login(loginRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("패스워드가 일치하지 않습니다.", exception.getMessage());
+
+    }
+
+    @Test
+    @DisplayName("로그인 실패 - 회원정보가 존재하지 않는 경우")
+    void loginFailsForNonexistentMember() {
+
+        // Given
+        String email = "b2c@example.com";
+        String password = "123456789";
+
+        Mockito.when(b2cMemberRepository.findByEmail(email))
+                .thenReturn(Optional.empty());
+
+        // When
+        LoginRequest loginRequest = new LoginRequest(email, password);
+        EntityNotFoundException exception = Assertions.assertThrows(
+                EntityNotFoundException.class, () -> b2cMemberAuthService.login(loginRequest)
+        );
+
+        // Then
+        Assertions.assertEquals("회원정보가 존재하지 않습니다.", exception.getMessage());
+
+    }
+}


### PR DESCRIPTION
## 🔘Part 
-Admin, B2B, B2C 회원가입, 로그인 테스트

## 🔎 작업 내용 
- 회원가입 성공
- 회원가입 실패 : 기가입자인 경우
- 로그인 성공 
- 로그인 실패 : 패스워드가 일치하지 않는 경우
- 로그인 실패 : 회원정보가 존재하지 않는 경우

## 🔧 앞으로의 과제 
- 없음

## ➕ 이슈 링크 
- #81 
