### PR TITLE
[#84] feat: B2B 이미지 등록, 삭제 수정 및 TEST 코드

### DIFF
--- a/b2b/build.gradle
+++ b/b2b/build.gradle
@@ -11,6 +11,8 @@ dependencies {
 	implementation project(':domain')
 	implementation project(':common')
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
+
+	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/b2b/build.gradle
+++ b/b2b/build.gradle
@@ -11,8 +11,6 @@ dependencies {
 	implementation project(':domain')
 	implementation project(':common')
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
-
-	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 }
 
 tasks.register("prepareKotlinBuildScriptModel"){}

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/controller/FileUploadController.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/controller/FileUploadController.java
@@ -1,7 +1,7 @@
 package com.sparta.b2b.fileUpload.controller;
 
 import com.sparta.b2b.fileUpload.dto.ImangeUploadedResponse;
-import com.sparta.b2b.fileUpload.service.FileUploadService;
+import com.sparta.b2b.fileUpload.service.FileManageService;
 import com.sparta.common.annotation.CheckAuth;
 import com.sparta.common.enums.Role;
 import lombok.RequiredArgsConstructor;
@@ -19,7 +19,7 @@ import java.util.List;
 @RequestMapping("/api")
 public class FileUploadController {
 
-	private final FileUploadService fileUploadService;
+	private final FileManageService fileUploadService;
 
 	@CheckAuth(role = Role.B2B)
 	@PostMapping("/products/images")

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/controller/FileUploadController.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/controller/FileUploadController.java
@@ -21,6 +21,7 @@ public class FileUploadController {
 
 	private final FileManageService fileUploadService;
 
+	@Deprecated
 	@CheckAuth(role = Role.B2B)
 	@PostMapping("/products/images")
 	public ImangeUploadedResponse uploadFiles(@RequestParam("images") List<MultipartFile> files) throws IOException {//images 갯수 제한(과금우려), 용량 제한 필수로 지정해야함

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/controller/FileUploadController.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/controller/FileUploadController.java
@@ -1,7 +1,9 @@
 package com.sparta.b2b.fileUpload.controller;
 
-import com.sparta.b2b.fileUpload.dto.ApiResponse;
+import com.sparta.b2b.fileUpload.dto.ImangeUploadedResponse;
 import com.sparta.b2b.fileUpload.service.FileUploadService;
+import com.sparta.common.annotation.CheckAuth;
+import com.sparta.common.enums.Role;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -19,12 +21,13 @@ public class FileUploadController {
 
 	private final FileUploadService fileUploadService;
 
-	// 다건 파일 업로드
+	@CheckAuth(role = Role.B2B)
 	@PostMapping("/products/images")
-	public ApiResponse uploadFiles(@RequestParam("images") List<MultipartFile> files) throws IOException {
+	public ImangeUploadedResponse uploadFiles(@RequestParam("images") List<MultipartFile> files) throws IOException {//images 갯수 제한(과금우려), 용량 제한 필수로 지정해야함
 		// 파일업로드 서비스로직
-		ApiResponse apiResponse = fileUploadService.uploadFiles(files);
+		ImangeUploadedResponse apiResponse = fileUploadService.uploadFiles(files);
 		return apiResponse;
 	}
-
+	// 파일 업로드 api 호출 -> url 포함하여 상품등록 api 호출
+	// 상품 등록시 이미지 등록이 같이 되도록
 }

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/dto/ImangeUploadedResponse.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/dto/ImangeUploadedResponse.java
@@ -12,13 +12,14 @@ import java.util.List;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ApiResponse {
+public class ImangeUploadedResponse {// 이름수정
 
 	public List<ImageInfo> images;
 
-	public static ApiResponse of(List<ImageInfo> infos) {
-		return ApiResponse.builder()
+	public static ImangeUploadedResponse of(List<ImageInfo> infos) {
+		return ImangeUploadedResponse.builder()
 		.images(infos)
 		.build();
 	}
 }
+

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
@@ -17,8 +17,12 @@ import java.util.stream.Collectors;
 public class FileManageService {
 
 	private final S3ManageService s3ManageService;
+	private static final long MAX_FILE_SIZE = 5 * 1024 * 1024; // TODO : confg에 넣으면 좋을듯
 
 	public ImangeUploadedResponse uploadFiles(List<MultipartFile> files) {
+
+		validateFiles(files);
+
 		// 각 파일 업로드를 병렬 스트림으로 처리
 		List<ImageInfo> infos = files.parallelStream()
 			.map(file -> {
@@ -32,6 +36,33 @@ public class FileManageService {
 			.collect(Collectors.toList());
 
 		return ImangeUploadedResponse.of(infos);
+	}
+
+
+	private void validateFiles(List<MultipartFile> files) {
+		if (files == null || files.isEmpty()) {
+			throw new IllegalArgumentException("파일 목록이 비어있습니다.");
+		}
+
+		if (files.size() > 10) {
+			throw new IllegalArgumentException("최대 파일 갯수를 초과하였습니다.");
+		}
+
+		for (MultipartFile file : files) {
+			if (file == null || file.isEmpty()) {
+				throw new IllegalArgumentException("파일이 비어있거나 null입니다.");
+			}
+
+			if (file.getSize() > MAX_FILE_SIZE) {
+				throw new IllegalArgumentException(
+					String.format("파일 크기가 초과되었습니다. 파일명: %s, 크기: %.2fMB (최대 허용 크기: %.2fMB)",
+						file.getOriginalFilename(),
+						file.getSize() / (1024.0 * 1024.0),
+						MAX_FILE_SIZE / (1024.0 * 1024.0)
+					)
+				);
+			}
+		}
 	}
 
 

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
@@ -2,6 +2,7 @@ package com.sparta.b2b.fileUpload.service;
 
 import com.sparta.b2b.fileUpload.dto.ImangeUploadedResponse;
 import com.sparta.b2b.fileUpload.dto.ImageInfo;
+import jakarta.persistence.EntityNotFoundException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -41,7 +42,7 @@ public class FileManageService {
 
 	public void validateFiles(List<MultipartFile> files) {
 		if (files == null || files.isEmpty()) {
-			throw new IllegalArgumentException("파일 목록이 비어있습니다.");
+			throw new EntityNotFoundException("파일 목록이 비어있습니다.");
 		}
 
 		if (files.size() > 10) {
@@ -50,7 +51,7 @@ public class FileManageService {
 
 		for (MultipartFile file : files) {
 			if (file == null || file.isEmpty()) {
-				throw new IllegalArgumentException("파일이 비어있거나 null입니다.");
+				throw new EntityNotFoundException("파일이 비어있거나 null입니다.");
 			}
 
 			if (file.getSize() > MAX_FILE_SIZE) {

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
@@ -39,7 +39,7 @@ public class FileManageService {
 	}
 
 
-	private void validateFiles(List<MultipartFile> files) {
+	public void validateFiles(List<MultipartFile> files) {
 		if (files == null || files.isEmpty()) {
 			throw new IllegalArgumentException("파일 목록이 비어있습니다.");
 		}

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
@@ -14,16 +14,16 @@ import java.util.stream.Collectors;
 @Slf4j
 @Service
 @RequiredArgsConstructor
-public class FileUploadService {
+public class FileManageService {
 
-	private final S3Upload s3Upload;
+	private final S3ManageService s3ManageService;
 
 	public ImangeUploadedResponse uploadFiles(List<MultipartFile> files) {
 		// 각 파일 업로드를 병렬 스트림으로 처리
 		List<ImageInfo> infos = files.parallelStream()
 			.map(file -> {
 				try {
-					String url = s3Upload.upload(file);
+					String url = s3ManageService.upload(file);
 					return new ImageInfo(url);
 				} catch (IOException e) {
 					throw new RuntimeException(e); // 예외를 RuntimeException으로 변환
@@ -32,5 +32,11 @@ public class FileUploadService {
 			.collect(Collectors.toList());
 
 		return ImangeUploadedResponse.of(infos);
+	}
+
+
+	// 이미지 삭제 메서드
+	public void delete(String imageUrl) {
+		s3ManageService.delete(imageUrl);
 	}
 }

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileUploadService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileUploadService.java
@@ -1,14 +1,14 @@
 package com.sparta.b2b.fileUpload.service;
 
-import com.sparta.b2b.fileUpload.dto.ApiResponse;
+import com.sparta.b2b.fileUpload.dto.ImangeUploadedResponse;
 import com.sparta.b2b.fileUpload.dto.ImageInfo;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.stream.Collectors;
 
 
 @Slf4j
@@ -18,16 +18,19 @@ public class FileUploadService {
 
 	private final S3Upload s3Upload;
 
-	public ApiResponse uploadFiles(List<MultipartFile> files) throws IOException {
-		// files
-		List<ImageInfo> infos= new ArrayList<>();
+	public ImangeUploadedResponse uploadFiles(List<MultipartFile> files) {
+		// 각 파일 업로드를 병렬 스트림으로 처리
+		List<ImageInfo> infos = files.parallelStream()
+			.map(file -> {
+				try {
+					String url = s3Upload.upload(file);
+					return new ImageInfo(url);
+				} catch (IOException e) {
+					throw new RuntimeException(e); // 예외를 RuntimeException으로 변환
+				}
+			})
+			.collect(Collectors.toList());
 
-		for (MultipartFile file : files) {
-			String url = s3Upload.upload(file);
-			infos.add(new ImageInfo(url));
-		}
-
-		ApiResponse apiResponse = ApiResponse.of(infos);
-		return apiResponse;
+		return ImangeUploadedResponse.of(infos);
 	}
 }

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -32,6 +32,7 @@ public class S3ManageService {
 
 		amazonS3.putObject(new PutObjectRequest(bucket, "/product-image/"+s3FileName, multipartFile.getInputStream(), objMeta)
 			.withCannedAcl(CannedAccessControlList.PublicRead));
+
 		String url = amazonS3.getUrl(bucket, s3FileName).toString();
 
 		return url;

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -5,6 +5,7 @@ import com.amazonaws.services.s3.model.CannedAccessControlList;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
@@ -12,9 +13,11 @@ import org.springframework.web.multipart.MultipartFile;
 import java.io.IOException;
 import java.util.UUID;
 
+
+@Slf4j
 @RequiredArgsConstructor
 @Service
-public class S3Upload {
+public class S3ManageService {
 
 	@Value("${cloud.aws.s3.bucket}")
 	private String bucket;
@@ -22,23 +25,37 @@ public class S3Upload {
 	private final AmazonS3 amazonS3;
 
 	public String upload(MultipartFile multipartFile) throws IOException {
-		//고유한번호 생성(램덤번호생성) 실제이름 보단 임의로 지정 될수 있도록
-		String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
+		//고유한번호 생성(램덤번호생성) 실제이름 보단 임의로 지정 될수 있도록//
+		String s3FileName = UUID.randomUUID().toString();
 
-		// ObjectMetadata 객체 생성: 파일의 메타데이터를 설정하기 위한 객체
 		ObjectMetadata objMeta = new ObjectMetadata();
 
-		// AWS S3에 파일 업로드
-		// bucket: 업로드할 S3 버킷 이름
-		// s3FileName: S3에 저장될 파일 이름
-		// multipartFile.getInputStream(): 업로드할 파일의 입력 스트림
-		// objMeta: 파일의 메타데이터 객체 (파일 크기 및 기타 정보 포함)
-//		amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
 		amazonS3.putObject(new PutObjectRequest(bucket, "/product-image/"+s3FileName, multipartFile.getInputStream(), objMeta)
 			.withCannedAcl(CannedAccessControlList.PublicRead));
 		String url = amazonS3.getUrl(bucket, s3FileName).toString();
 
 		return url;
+	}
+
+	public void delete(String imageUrl) {
+		// URL에서 파일 이름 추출
+		String fileName = extractFileNameFromUrl(imageUrl);
+		try {
+			amazonS3.deleteObject(bucket, fileName);
+			log.info("S3에서 파일 삭제 완료: {}", fileName);
+		} catch (Exception e) {
+			log.error("S3에서 파일 삭제 실패: {}", fileName, e);
+		}
+	}
+
+	// TODO : 검토 필요
+	// URL에서 S3 파일 경로 추출
+	private String extractFileNameFromUrl(String imageUrl) {
+		String bucketUrl = amazonS3.getUrl(bucket, imageUrl).toString();
+		if (!imageUrl.startsWith(bucketUrl)) {
+			log.error("유효하지 않은 파일 URL: {}", imageUrl);
+		}
+		return imageUrl.substring(bucketUrl.length());
 	}
 
 }

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -30,7 +30,7 @@ public class S3ManageService {
 
 		ObjectMetadata objMeta = new ObjectMetadata();
 
-		amazonS3.putObject(new PutObjectRequest(bucket, "/product-image/"+s3FileName, multipartFile.getInputStream(), objMeta)
+		amazonS3.putObject(new PutObjectRequest(bucket, "product-image/"+s3FileName, multipartFile.getInputStream(), objMeta)
 			.withCannedAcl(CannedAccessControlList.PublicRead));
 
 		String url = amazonS3.getUrl(bucket, s3FileName).toString();

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -48,13 +48,14 @@ public class S3ManageService {
 		}
 	}
 
-	// TODO : 검토 필요
-	// URL에서 S3 파일 경로 추출
+	// URL에서 S3 파일 경로 추출 // s3 + fileName
 	private String extractFileNameFromUrl(String imageUrl) {
-		String bucketUrl = amazonS3.getUrl(bucket, imageUrl).toString();
+		String bucketUrl = amazonS3.getUrl(bucket, "").toString();
+
 		if (!imageUrl.startsWith(bucketUrl)) {
 			log.error("유효하지 않은 파일 URL: {}", imageUrl);
 		}
+
 		return imageUrl.substring(bucketUrl.length());
 	}
 

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3Upload.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3Upload.java
@@ -22,15 +22,11 @@ public class S3Upload {
 	private final AmazonS3 amazonS3;
 
 	public String upload(MultipartFile multipartFile) throws IOException {
-		//고유한번호 생성(램덤번호생성)
+		//고유한번호 생성(램덤번호생성) 실제이름 보단 임의로 지정 될수 있도록
 		String s3FileName = UUID.randomUUID() + "-" + multipartFile.getOriginalFilename();
 
 		// ObjectMetadata 객체 생성: 파일의 메타데이터를 설정하기 위한 객체
 		ObjectMetadata objMeta = new ObjectMetadata();
-
-		// 파일의 크기(Content-Length)를 메타데이터에 설정
-		// multipartFile.getInputStream().available()는 파일의 크기를 반환
-		objMeta.setContentLength(multipartFile.getInputStream().available());
 
 		// AWS S3에 파일 업로드
 		// bucket: 업로드할 S3 버킷 이름
@@ -38,7 +34,7 @@ public class S3Upload {
 		// multipartFile.getInputStream(): 업로드할 파일의 입력 스트림
 		// objMeta: 파일의 메타데이터 객체 (파일 크기 및 기타 정보 포함)
 //		amazonS3.putObject(bucket, s3FileName, multipartFile.getInputStream(), objMeta);
-		amazonS3.putObject(new PutObjectRequest(bucket, s3FileName, multipartFile.getInputStream(), objMeta)
+		amazonS3.putObject(new PutObjectRequest(bucket, "/product-image/"+s3FileName, multipartFile.getInputStream(), objMeta)
 			.withCannedAcl(CannedAccessControlList.PublicRead));
 		String url = amazonS3.getUrl(bucket, s3FileName).toString();
 

--- a/b2b/src/main/java/com/sparta/b2b/product/controller/ProductController.java
+++ b/b2b/src/main/java/com/sparta/b2b/product/controller/ProductController.java
@@ -16,6 +16,9 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.List;
 
 
 @RestController
@@ -29,12 +32,12 @@ public class ProductController {
 	@PostMapping()
 	public ResponseEntity<ProductCreateResponse> createProduct(
 		@RequestBody @Valid ProductCreateRequest request,
-		@LoginMember(role = Role.B2B) MemberSession memberSession
-
+		@LoginMember(role = Role.B2B) MemberSession memberSession,
+		@RequestParam("images") List<MultipartFile> productImageFiles
 	) {
 		return ResponseEntity
 			.status(HttpStatus.CREATED)
-			.body(productService.createProduct(memberSession.memberId(), request));
+			.body(productService.createProduct(memberSession.memberId(), request, productImageFiles));
 	}
 
 	@CheckAuth(role = Role.B2B)

--- a/b2b/src/main/java/com/sparta/b2b/product/controller/ProductController.java
+++ b/b2b/src/main/java/com/sparta/b2b/product/controller/ProductController.java
@@ -31,9 +31,9 @@ public class ProductController {
 	@CheckAuth(role = Role.B2B)
 	@PostMapping()
 	public ResponseEntity<ProductCreateResponse> createProduct(
-		@RequestBody @Valid ProductCreateRequest request,
+		@RequestPart(value = "requestDto") @Valid ProductCreateRequest request,
 		@LoginMember(role = Role.B2B) MemberSession memberSession,
-		@RequestParam("images") List<MultipartFile> productImageFiles
+		@RequestPart(value = "images") List<MultipartFile> productImageFiles
 	) {
 		return ResponseEntity
 			.status(HttpStatus.CREATED)

--- a/b2b/src/main/java/com/sparta/b2b/product/dto/request/ProductCreateRequest.java
+++ b/b2b/src/main/java/com/sparta/b2b/product/dto/request/ProductCreateRequest.java
@@ -32,11 +32,7 @@ public record ProductCreateRequest(
 	Category category,
 
 	@NotNull
-	Category.SubCategory subCategory,
-
-	@NotNull
-	List<ImageInfo> images
-
+	Category.SubCategory subCategory
 ) {
 
 	public Product toProductEntity(B2BMember member) {

--- a/b2b/src/main/java/com/sparta/b2b/product/service/ProductService.java
+++ b/b2b/src/main/java/com/sparta/b2b/product/service/ProductService.java
@@ -69,6 +69,7 @@ public class ProductService {
 		return ProductCreateResponse.from(saveedProduct, savedImageList);
 	}
 
+
 	@Transactional(readOnly = true)
 	public ProductSearchResponse searchProduct(Long memberId, Long productId) {
 		Product product = productRepository.findById(productId)
@@ -76,6 +77,7 @@ public class ProductService {
 
 		return ProductSearchResponse.from(product);
 	}
+
 
 	public PageProductResponse totalSearchProduct(
 		Long memberId, int page, int size, String orderBy, String sortBy
@@ -86,6 +88,7 @@ public class ProductService {
 		return PageProductResponse.from(productPage);
 	}
 
+
 	public ProductUpdateResponse updateProduct(Long memberId, Long productId, ProductUpdateRequest request) {
 		Product existingProduct = productRepository.findById(productId)
 			.orElseThrow(() -> new EntityNotFoundException("해당 ID를 가진 상품이 존재하지 않습니다."));
@@ -95,6 +98,7 @@ public class ProductService {
 
 		return ProductUpdateResponse.from(savedProduct);
 	}
+
 
 	public void deleteProduct(Long memberId, Long productId) {
 		B2BMember member = b2bMemberRepository.findById(memberId)
@@ -120,5 +124,4 @@ public class ProductService {
 
 		productRepository.deleteById(productId);
 	}
-
 }

--- a/b2b/src/main/java/com/sparta/b2b/product/service/ProductService.java
+++ b/b2b/src/main/java/com/sparta/b2b/product/service/ProductService.java
@@ -114,8 +114,10 @@ public class ProductService {
 		// 이미지 삭제
 		List<Image> allByProduct = imageRepository.findAllByProduct(product);
 		for (Image image : allByProduct) {
-			fileManageService.delete(image.getImg_url());
+			fileManageService.delete(image.getImg_url()); // S3 에서 삭제
+			imageRepository.delete(image); // DB에서 삭제
 		}
+
 		productRepository.deleteById(productId);
 	}
 

--- a/b2b/src/main/java/com/sparta/b2b/product/service/ProductService.java
+++ b/b2b/src/main/java/com/sparta/b2b/product/service/ProductService.java
@@ -1,13 +1,14 @@
 package com.sparta.b2b.product.service;
 
+import com.sparta.b2b.fileUpload.dto.ImangeUploadedResponse;
 import com.sparta.b2b.fileUpload.dto.ImageInfo;
+import com.sparta.b2b.fileUpload.service.FileUploadService;
 import com.sparta.b2b.product.dto.request.ProductCreateRequest;
 import com.sparta.b2b.product.dto.request.ProductUpdateRequest;
 import com.sparta.b2b.product.dto.response.PageProductResponse;
 import com.sparta.b2b.product.dto.response.ProductCreateResponse;
 import com.sparta.b2b.product.dto.response.ProductSearchResponse;
 import com.sparta.b2b.product.dto.response.ProductUpdateResponse;
-import com.sparta.common.dto.MemberSession;
 import com.sparta.impostor.commerce.backend.common.exception.AuthenticationFailedException;
 import com.sparta.impostor.commerce.backend.common.exception.ForbiddenAccessException;
 import com.sparta.impostor.commerce.backend.domain.b2bMember.entity.B2BMember;
@@ -23,11 +24,10 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Sort;
-import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.multipart.MultipartFile;
 
-import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -40,9 +40,13 @@ public class ProductService {
 	private final ProductRepository productRepository;
 	private final B2BMemberRepository b2bMemberRepository;
 	private final ImageRepository imageRepository;
+	private final FileUploadService fileUploadService;
 
 
-	public ProductCreateResponse createProduct(Long memberId, ProductCreateRequest request) {
+	public ProductCreateResponse createProduct(Long memberId, ProductCreateRequest request, List<MultipartFile> productImageFiles) {
+
+		ImangeUploadedResponse imangeUploadedResponse = fileUploadService.uploadFiles(productImageFiles);
+
 		B2BMember member = b2bMemberRepository.findById(memberId)
 			.orElseThrow(() -> new EntityNotFoundException("해당 ID를 가진 멤버가 존재하지 않습니다."));
 
@@ -52,7 +56,7 @@ public class ProductService {
 
 		Product saveedProduct = productRepository.save(request.toProductEntity(member));
 
-		List<ImageInfo> imageinfos = request.images();
+		List<ImageInfo> imageinfos = imangeUploadedResponse.getImages();
 		List<Image> images = new ArrayList<>();
 
 		for (ImageInfo imageinfo : imageinfos) {

--- a/b2b/src/test/java/com/sparta/b2b/fileUpload/FileValidationTest.java
+++ b/b2b/src/test/java/com/sparta/b2b/fileUpload/FileValidationTest.java
@@ -2,6 +2,7 @@ package com.sparta.b2b.fileUpload;
 
 import com.sparta.b2b.fileUpload.service.FileManageService;
 
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.mockito.Mockito;
@@ -21,7 +22,7 @@ public class FileValidationTest {
 		FileManageService fileManageService = new FileManageService(null);
 
 		// when
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+		EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
 			() -> fileManageService.validateFiles(null));
 
 		// then
@@ -32,7 +33,7 @@ public class FileValidationTest {
 	void validateFiles_shouldThrowException_whenFilesAreEmpty() {
 		FileManageService fileManageService = new FileManageService(null);
 
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+		EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
 			() -> fileManageService.validateFiles(Collections.emptyList()));
 
 		assertEquals("파일 목록이 비어있습니다.", exception.getMessage());
@@ -62,7 +63,7 @@ public class FileValidationTest {
 
 		List<MultipartFile> files = List.of(emptyFile);
 
-		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+		EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
 			() -> fileManageService.validateFiles(files));
 
 		assertEquals("파일이 비어있거나 null입니다.", exception.getMessage());

--- a/b2b/src/test/java/com/sparta/b2b/fileUpload/FileValidationTest.java
+++ b/b2b/src/test/java/com/sparta/b2b/fileUpload/FileValidationTest.java
@@ -1,0 +1,102 @@
+package com.sparta.b2b.fileUpload;
+
+import com.sparta.b2b.fileUpload.service.FileManageService;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+public class FileValidationTest {
+
+	@Test
+	void validateFiles_shouldThrowException_whenFilesAreNull() {
+		// given
+		FileManageService fileManageService = new FileManageService(null);
+
+		// when
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			() -> fileManageService.validateFiles(null));
+
+		// then
+		assertEquals("파일 목록이 비어있습니다.", exception.getMessage());
+	}
+
+	@Test
+	void validateFiles_shouldThrowException_whenFilesAreEmpty() {
+		FileManageService fileManageService = new FileManageService(null);
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			() -> fileManageService.validateFiles(Collections.emptyList()));
+
+		assertEquals("파일 목록이 비어있습니다.", exception.getMessage());
+	}
+
+	@Test
+	void validateFiles_shouldThrowException_whenFileCountExceedsLimit() {
+		FileManageService fileManageService = new FileManageService(null);
+
+		List<MultipartFile> files = new ArrayList<>();
+		for (int i = 0; i < 11; i++) {
+			files.add(Mockito.mock(MultipartFile.class));
+		}
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			() -> fileManageService.validateFiles(files));
+
+		assertEquals("최대 파일 갯수를 초과하였습니다.", exception.getMessage());
+	}
+
+	@Test
+	void validateFiles_shouldThrowException_whenFileIsNullOrEmpty() {
+		FileManageService fileManageService = new FileManageService(null);
+
+		MultipartFile emptyFile = Mockito.mock(MultipartFile.class);
+		Mockito.when(emptyFile.isEmpty()).thenReturn(true);
+
+		List<MultipartFile> files = List.of(emptyFile);
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			() -> fileManageService.validateFiles(files));
+
+		assertEquals("파일이 비어있거나 null입니다.", exception.getMessage());
+	}
+
+	@Test
+	void validateFiles_shouldThrowException_whenFileSizeExceedsLimit() {
+		FileManageService fileManageService = new FileManageService(null);
+
+		MultipartFile largeFile = Mockito.mock(MultipartFile.class);
+		Mockito.when(largeFile.isEmpty()).thenReturn(false);
+		Mockito.when(largeFile.getSize()).thenReturn(6 * 1024 * 1024L); // 6MB
+		Mockito.when(largeFile.getOriginalFilename()).thenReturn("largeFile.jpg");
+
+		List<MultipartFile> files = List.of(largeFile);
+
+		IllegalArgumentException exception = assertThrows(IllegalArgumentException.class,
+			() -> fileManageService.validateFiles(files));
+
+		assertTrue(exception.getMessage().contains("파일 크기가 초과되었습니다."));
+		assertTrue(exception.getMessage().contains("largeFile.jpg"));
+	}
+
+	@Test
+	void validateFiles_shouldPass_whenAllFilesAreValid() {
+		FileManageService fileManageService = new FileManageService(null);
+
+		MultipartFile validFile = Mockito.mock(MultipartFile.class);
+		Mockito.when(validFile.isEmpty()).thenReturn(false);
+		Mockito.when(validFile.getSize()).thenReturn(4 * 1024 * 1024L); // 4MB
+		Mockito.when(validFile.getOriginalFilename()).thenReturn("validFile.jpg");
+
+		List<MultipartFile> files = List.of(validFile);
+
+		assertDoesNotThrow(() -> fileManageService.validateFiles(files));
+	}
+}

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/image/repository/ImageRepository.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/image/repository/ImageRepository.java
@@ -2,7 +2,13 @@ package com.sparta.impostor.commerce.backend.domain.image.repository;
 
 
 import com.sparta.impostor.commerce.backend.domain.image.entity.Image;
+import com.sparta.impostor.commerce.backend.domain.product.entity.Product;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 public interface ImageRepository extends JpaRepository<Image, String> {
+
+	List<Image> findAllByProduct(Product product);
+
 }


### PR DESCRIPTION
## 🔘Part 
-B2B 화면에서 주문 리스트 조회

## 🔎 작업 내용 
- 상품 등록시 이미지 함께 등록
  - 등록 시 image 갯수 제한: 10개 이하로 제한
  - 등록 시 용량 제한 : 사진 개당 5MB이하로 제한
- 상품 삭제 시 이미지 삭제
  - DB 이미지 삭제
- test 코드 작성
  - 파일 갯수, 용량 제한 설정에 대한 test

## 🔧 앞으로의 과제 
- 전체적인 코드 리팩토링 필요
  - 사용하지 않는 클래스 정리
  - 주석 정리
  - 고아이미지 삭제 안되는 부분 해결

## ➕ 이슈 링크 
- #84 
