### PR TITLE
[#107] Fix: 특정상태 B2C 회원 조회 에러 및 B2BMemberPageResponse 수정 

### DIFF
--- a/admin/src/main/java/com/sparta/admin/member/controller/B2CSearchController.java
+++ b/admin/src/main/java/com/sparta/admin/member/controller/B2CSearchController.java
@@ -1,18 +1,14 @@
 package com.sparta.admin.member.controller;
 
-import com.sparta.admin.member.dto.request.B2CMemberSearchRequest;
 import com.sparta.admin.member.dto.response.B2CMemberPageResponse;
 import com.sparta.admin.member.service.B2CSearchService;
 import com.sparta.common.annotation.CheckAuth;
 import com.sparta.common.enums.Role;
+import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.PageRequest;
-import org.springframework.data.domain.Pageable;
-import org.springframework.data.domain.Sort;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.ModelAttribute;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequestMapping("/api/admin/b2c-members")
@@ -21,20 +17,55 @@ public class B2CSearchController {
 
   private final B2CSearchService b2cSearchService;
 
-  // B2C 회원 전체 조회
+  /**
+   * B2C 회원 전체 조회
+   *
+   * @param page    현재 페이지 (기본값 1)
+   * @param size    페이지 당 사이즈 (기본값 10)
+   * @param sortBy  정렬 기준 (기본값 id)
+   * @param orderBy 정렬 방향 (기본값 asc)
+   * @return B2C 회원 목록
+   */
+
   @CheckAuth(role = Role.ADMIN)
-  @GetMapping
-  public B2CMemberPageResponse getB2CMembers(@ModelAttribute B2CMemberSearchRequest request) {
+  @GetMapping(produces = "application/json")
+  public ResponseEntity<B2CMemberPageResponse> getB2CMembers(
+          @RequestParam(required = false, defaultValue = "1") int page,
+          @RequestParam(required = false, defaultValue = "10") int size,
+          @RequestParam(required = false, defaultValue = "id") String sortBy,
+          @RequestParam(required = false, defaultValue = "asc") String orderBy
+  ) {
+    return ResponseEntity.status(HttpStatus.OK)
+            .body(b2cSearchService.getB2CMembers(page, size, sortBy, orderBy));
+  }
 
-    request.setDefaults();
 
-    // Pageable 생성
-    Sort.Direction direction =
-        request.getOrderBy().equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
 
-    Pageable pageable = PageRequest.of(request.getPage() - 1, request.getSize(),
-        Sort.by(direction, request.getSortBy()));
+  /**
+   * 특정 상태를 가진 B2C 회원 조회 (status: ACTIVE, INACTIVE)
+   *
+   * @param status  B2C 회원 상태 (ACTIVE, INACTIVE)
+   * @param page    현재 페이지 (기본값 1)
+   * @param size    페이지 당 사이즈 (기본값 10)
+   * @param sortBy  정렬 기준 (기본값 id)
+   * @param orderBy 정렬 방향 (기본값 asc)
+   * @return 특정 상태의 B2C 회원 목록
+   */
 
-    return b2cSearchService.getB2CMembers(request.getStatus(), pageable);
+  @CheckAuth(role = Role.ADMIN)
+  @GetMapping(value = "/status/{status}")
+  public ResponseEntity<B2CMemberPageResponse> getB2CMembersByStatus(
+          @PathVariable String status,
+          @RequestParam(required = false, defaultValue = "1") int page,
+          @RequestParam(required = false, defaultValue = "10") int size,
+          @RequestParam(required = false, defaultValue = "id") String sortBy,
+          @RequestParam(required = false, defaultValue = "asc") String orderBy
+  ) {
+
+    B2CMemberStatus b2cMemberStatus = B2CMemberStatus.valueOf(status.toUpperCase());
+
+    return ResponseEntity.status(HttpStatus.OK)
+            .body(b2cSearchService.getB2CMembersByStatus(page, size, sortBy, orderBy, b2cMemberStatus));
+
   }
 }

--- a/admin/src/main/java/com/sparta/admin/member/dto/response/B2BMemberPageResponse.java
+++ b/admin/src/main/java/com/sparta/admin/member/dto/response/B2BMemberPageResponse.java
@@ -5,7 +5,6 @@ import java.util.List;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 
-
 @Getter
 public class B2BMemberPageResponse {
 

--- a/admin/src/main/java/com/sparta/admin/member/dto/response/B2BMemberPageResponse.java
+++ b/admin/src/main/java/com/sparta/admin/member/dto/response/B2BMemberPageResponse.java
@@ -5,16 +5,20 @@ import java.util.List;
 import lombok.Getter;
 import org.springframework.data.domain.Page;
 
+
 @Getter
 public class B2BMemberPageResponse {
 
-  private List<B2BMemberResponse> members;
-  private Integer totalPages;
-  private Long totalElements;
+  private final List<B2BMemberResponse> contents;  // List 명 contents
+  private final Integer page;                      // 현재 페이지
+  private final Integer size;                      // 페이지 당 사이즈
+  private final Integer totalPage;                 // 총 페이지 수
 
-  public B2BMemberPageResponse(Page<B2BMember> b2bMemberPage) {
-    this.members = b2bMemberPage.map(B2BMemberResponse::from).stream().toList();
-    this.totalPages = b2bMemberPage.getTotalPages();
-    this.totalElements = b2bMemberPage.getTotalElements();
+
+  public B2BMemberPageResponse(Page<B2BMember> b2bMemberPage, int page, int size) {
+    this.contents = b2bMemberPage.map(B2BMemberResponse::from).toList();
+    this.page = page;                            // 요청한 페이지
+    this.size = size;                            // 페이지 당 항목 수
+    this.totalPage = b2bMemberPage.getTotalPages();  // 총 페이지 수
   }
 }

--- a/admin/src/main/java/com/sparta/admin/member/dto/response/B2CMemberPageResponse.java
+++ b/admin/src/main/java/com/sparta/admin/member/dto/response/B2CMemberPageResponse.java
@@ -1,26 +1,21 @@
 package com.sparta.admin.member.dto.response;
 
 import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
-import java.util.List;
+import lombok.Getter;
 import org.springframework.data.domain.Page;
 
-public record B2CMemberPageResponse(
+import java.util.List;
 
-    List<B2CMemberResponse> contents,
-    int page,
-    int size,
-    int totalPages
-) {
+@Getter
+public class B2CMemberPageResponse {
+    private final List<B2CMemberResponse> members;
+    private final Integer totalPages;
+    private final Long totalElements;
 
-  public B2CMemberPageResponse(Page<B2CMember> pageResponse) {
-    this(
-        pageResponse.getContent().stream()
-            .map(B2CMemberResponse::from)
-            .toList(),
-        pageResponse.getPageable().getPageNumber() + 1,
-        pageResponse.getPageable().getPageSize(),
-        pageResponse.getTotalPages()
-    );
-  }
 
+    public B2CMemberPageResponse(Page<B2CMember> b2cMemberPage) {
+        this.members = b2cMemberPage.map(B2CMemberResponse::from).toList();
+        this.totalPages = b2cMemberPage.getTotalPages();
+        this.totalElements = b2cMemberPage.getTotalElements();
+    }
 }

--- a/admin/src/main/java/com/sparta/admin/member/service/B2BSearchService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/B2BSearchService.java
@@ -39,7 +39,7 @@ public class B2BSearchService {
     Sort.Direction direction =
         orderBy.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
 
-    PageRequest pageRequest = PageRequest.of(page - 1, size, direction, sortBy, orderBy);
+    PageRequest pageRequest = PageRequest.of(page - 1, size, direction, sortBy);
 
     // 상태에 맞는 B2B 회원을 조회하여 Response 로 변환
     Page<B2BMember> b2bMemberPage = b2bMemberRepository.findByB2bMemberStatus(status, pageRequest);

--- a/admin/src/main/java/com/sparta/admin/member/service/B2BSearchService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/B2BSearchService.java
@@ -28,7 +28,7 @@ public class B2BSearchService {
     // 모든 B2B 회원을 조회하여 Response 로 변환
     Page<B2BMember> b2bMemberPage = b2bMemberRepository.findAll(pageRequest);
 
-    return new B2BMemberPageResponse(b2bMemberPage);
+    return new B2BMemberPageResponse(b2bMemberPage, page, size);
 
   }
 
@@ -44,7 +44,7 @@ public class B2BSearchService {
     // 상태에 맞는 B2B 회원을 조회하여 Response 로 변환
     Page<B2BMember> b2bMemberPage = b2bMemberRepository.findByB2bMemberStatus(status, pageRequest);
 
-    return new B2BMemberPageResponse(b2bMemberPage);
+    return new B2BMemberPageResponse(b2bMemberPage, page, size);
   }
 
 }

--- a/admin/src/main/java/com/sparta/admin/member/service/B2CSearchService.java
+++ b/admin/src/main/java/com/sparta/admin/member/service/B2CSearchService.java
@@ -1,12 +1,17 @@
 package com.sparta.admin.member.service;
 
+import com.sparta.admin.member.dto.response.B2BMemberPageResponse;
 import com.sparta.admin.member.dto.response.B2CMemberPageResponse;
+import com.sparta.impostor.commerce.backend.domain.b2bMember.entity.B2BMember;
+import com.sparta.impostor.commerce.backend.domain.b2bMember.enums.B2BMemberStatus;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.entity.B2CMember;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.enums.B2CMemberStatus;
 import com.sparta.impostor.commerce.backend.domain.b2cMember.repository.B2CMemberRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
 import org.springframework.stereotype.Service;
 
 @Service
@@ -15,19 +20,34 @@ public class B2CSearchService {
 
   private final B2CMemberRepository b2cMemberRepository;
 
-  // B2C 회원 조회 ( 전체 조회, 상태별 조회, 페이지네이션, 정렬 적용)
-  public B2CMemberPageResponse getB2CMembers(B2CMemberStatus status, Pageable pageable) {
-    Page<B2CMember> b2cMembers;
+  // 전체 B2C 회원 조회 (전체 조회, 페이지네이션, 정렬 적용)
+  public B2CMemberPageResponse getB2CMembers(int page, int size, String sortBy, String orderBy) {
 
-    // status 파라미터에 따라 필터링
-    if (status != null) {
-      // 상태에 맞는 회원들만 조회
-      b2cMembers = b2cMemberRepository.findByB2cMemberStatus(status, pageable);
-    } else {
-      // 상태가 주어지지 않으면, 모든 회원 조회
-      b2cMembers = b2cMemberRepository.findAll(pageable);
-    }
+    // 정렬 방향 결정
+    Sort.Direction direction =
+            orderBy.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
 
-    return new B2CMemberPageResponse(b2cMembers);
+    PageRequest pageRequest = PageRequest.of(page - 1, size, direction, sortBy);
+
+    // 모든 B2C 회원을 조회하여 Response 로 변환
+    Page<B2CMember> b2cMemberPage = b2cMemberRepository.findAll(pageRequest);
+
+    return new B2CMemberPageResponse(b2cMemberPage);
+
+  }
+
+  // 특정 status 애 해당하는 B2C 회원 조회 (status: INACTIVE, ACTIVE)
+  public B2CMemberPageResponse getB2CMembersByStatus(
+          int page, int size, String sortBy, String orderBy, B2CMemberStatus status) {
+
+    Sort.Direction direction =
+            orderBy.equalsIgnoreCase("desc") ? Sort.Direction.DESC : Sort.Direction.ASC;
+
+    PageRequest pageRequest = PageRequest.of(page - 1, size, direction, sortBy);
+
+    // 상태에 맞는 B2C 회원을 조회하여 Response 로 변환
+    Page<B2CMember> b2cMemberPage = b2cMemberRepository.findByB2cMemberStatus(status, pageRequest);
+
+    return new B2CMemberPageResponse(b2cMemberPage);
   }
 }


### PR DESCRIPTION
## 🔘Part 
- Admin

## 🔎 작업 내용 
- 특정 상태 B2C 회원 조회시, 전체 조회로 조회되는 이슈 해결
- B2BMemberPageResponse < List 명 contents로 변경
- B2BMemberPageResponse 내 contents의  totalPages, totalElements 이름 수정
- B2BSearchService 내 orderBy 제거


## 🔧 앞으로의 과제 
- 담당 영역 시작

## ➕ 이슈 링크 
- #107
