### PR TITLE
[#115]hotfix: B2B 상품 조금 큰 이미지 S3에 업로드가 안되는 버그 해결

### DIFF
--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -25,11 +25,17 @@ public class S3ManageService {
 	private final AmazonS3 amazonS3;
 
 	public String upload(MultipartFile multipartFile) throws IOException {
-		//고유한번호 생성(램덤번호생성) 실제이름 보단 임의로 지정 될수 있도록//
-		String s3FileName = "product-image/" + UUID.randomUUID().toString() + ".png";
+		String fileName = multipartFile.getOriginalFilename();
+		String ext = fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase();
+		if (!(ext.equals("jpg") || ext.equals("jpeg") || ext.equals("png"))) {
+			throw new IllegalArgumentException("지원되지 않는 확장자입니다. jpg, jpeg, png만 업로드 가능합니다.");
+		}
+		String contentType = multipartFile.getContentType();
+		String s3FileName = "product-image/" + UUID.randomUUID() + "." + ext;
 
 		ObjectMetadata objMeta = new ObjectMetadata();
-
+		objMeta.setContentType(contentType);
+		objMeta.setContentLength(multipartFile.getSize());
 		amazonS3.putObject(new PutObjectRequest(bucket, s3FileName, multipartFile.getInputStream(), objMeta)
 			.withCannedAcl(CannedAccessControlList.PublicRead));
 


### PR DESCRIPTION


## 🔘Part 
-B2B 화면에서 주문 리스트 조회

## 🔎 작업 내용
- 이미지가 조금이라도 커지면 클라우드 서버 환경에서 업로드가 안되는 문제 해결
- 업로드할 이미지 객체에 컨텐츠 타입을 명시하도록 변경
- 추가로 jpg, jpeg, png만 업로드가 가능하도록 확장자 검사 로직 추가

## 🔧 앞으로의 과제 
- main에 머지해서 테스트 해보고 되나 테스트 해봐야함..

## ➕ 이슈 링크 
- #115 