### PR TITLE
[#119] Feat: MDC, TraceId를 활용한 로그 추적 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ out/
 
 ### .env ###
 .env
+
+### application.log ###
+application.log

--- a/admin/src/main/resources/logback-spring.xml
+++ b/admin/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
 
     <!-- 로그 패턴 설정 -->
-    <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%thread] %logger{36} %msg%n"/>
+    <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [TRACE_ID: %X{traceId}] [%thread] %logger{36} %msg%n"/>
 
     <!-- ConsoleAppender 설정: 콘솔에 로그 출력 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">

--- a/admin/src/main/resources/logback-spring.xml
+++ b/admin/src/main/resources/logback-spring.xml
@@ -43,6 +43,7 @@
 
     <!-- MDC 관련 로그 추가 예시 (traceId 설정) -->
     <logger name="com.sparta" level="INFO">
+        <appender-ref ref="CONSOLE"/>
         <appender-ref ref="DAILY_LOG"/>
     </logger>
 

--- a/admin/src/main/resources/logback-spring.xml
+++ b/admin/src/main/resources/logback-spring.xml
@@ -16,35 +16,21 @@
         <file>./application.log</file>
         <append>true</append>
 
-    <!-- 로그 파일 롤링 정책: 하루 단위로 롤링 -->
+        <!-- 로그 파일 롤링 정책: 하루 단위로 롤링 -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>./application-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <!-- 최대 7일간의 로그를 보관 -->
             <maxHistory>7</maxHistory>
         </rollingPolicy>
 
-    <!-- 로그 형식 설정 -->
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 
-    <!-- Root Logger 설정 -->
+    <!-- Root Logger 설정 (애플리케이션 전체 적용) -->
     <root level="INFO">
-        <!-- 콘솔에 로그 출력 -->
         <appender-ref ref="CONSOLE"/>
-        <!-- 파일에 로그 출력 -->
         <appender-ref ref="DAILY_LOG"/>
     </root>
-
-    <!-- 특정 패키지나 클래스에서 더 상세한 로그 레벨 설정 가능 -->
-    <logger name="org.springframework" level="WARN"/>
-    <logger name="org.hibernate" level="ERROR"/>
-
-    <!-- MDC 관련 로그 추가 예시 (traceId 설정) -->
-    <logger name="com.sparta" level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="DAILY_LOG"/>
-    </logger>
 
 </configuration>

--- a/b2b/src/main/resources/logback-spring.xml
+++ b/b2b/src/main/resources/logback-spring.xml
@@ -19,32 +19,18 @@
         <!-- 로그 파일 롤링 정책: 하루 단위로 롤링 -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>./application-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <!-- 최대 7일간의 로그를 보관 -->
             <maxHistory>7</maxHistory>
         </rollingPolicy>
 
-        <!-- 로그 형식 설정 -->
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 
-    <!-- Root Logger 설정 -->
+    <!-- Root Logger 설정 (애플리케이션 전체 적용) -->
     <root level="INFO">
-        <!-- 콘솔에 로그 출력 -->
         <appender-ref ref="CONSOLE"/>
-        <!-- 파일에 로그 출력 -->
         <appender-ref ref="DAILY_LOG"/>
     </root>
-
-    <!-- 특정 패키지나 클래스에서 더 상세한 로그 레벨 설정 가능 -->
-    <logger name="org.springframework" level="WARN"/>
-    <logger name="org.hibernate" level="ERROR"/>
-
-    <!-- MDC 관련 로그 추가 예시 (traceId 설정) -->
-    <logger name="com.sparta" level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="DAILY_LOG"/>
-    </logger>
 
 </configuration>

--- a/b2b/src/main/resources/logback-spring.xml
+++ b/b2b/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
 
     <!-- 로그 패턴 설정 -->
-    <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%thread] %logger{36} %msg%n"/>
+    <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [TRACE_ID: %X{traceId}] [%thread] %logger{36} %msg%n"/>
 
     <!-- ConsoleAppender 설정: 콘솔에 로그 출력 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -43,6 +43,7 @@
 
     <!-- MDC 관련 로그 추가 예시 (traceId 설정) -->
     <logger name="com.sparta" level="INFO">
+        <appender-ref ref="CONSOLE"/>
         <appender-ref ref="DAILY_LOG"/>
     </logger>
 

--- a/b2c/src/main/resources/logback-spring.xml
+++ b/b2c/src/main/resources/logback-spring.xml
@@ -19,32 +19,18 @@
         <!-- 로그 파일 롤링 정책: 하루 단위로 롤링 -->
         <rollingPolicy class="ch.qos.logback.core.rolling.TimeBasedRollingPolicy">
             <fileNamePattern>./application-%d{yyyy-MM-dd}.log</fileNamePattern>
-            <!-- 최대 7일간의 로그를 보관 -->
             <maxHistory>7</maxHistory>
         </rollingPolicy>
 
-        <!-- 로그 형식 설정 -->
         <encoder>
             <pattern>${LOG_PATTERN}</pattern>
         </encoder>
     </appender>
 
-    <!-- Root Logger 설정 -->
+    <!-- Root Logger 설정 (애플리케이션 전체 적용) -->
     <root level="INFO">
-        <!-- 콘솔에 로그 출력 -->
         <appender-ref ref="CONSOLE"/>
-        <!-- 파일에 로그 출력 -->
         <appender-ref ref="DAILY_LOG"/>
     </root>
-
-    <!-- 특정 패키지나 클래스에서 더 상세한 로그 레벨 설정 가능 -->
-    <logger name="org.springframework" level="WARN"/>
-    <logger name="org.hibernate" level="ERROR"/>
-
-    <!-- MDC 관련 로그 추가 예시 (traceId 설정) -->
-    <logger name="com.sparta" level="INFO">
-        <appender-ref ref="CONSOLE"/>
-        <appender-ref ref="DAILY_LOG"/>
-    </logger>
 
 </configuration>

--- a/b2c/src/main/resources/logback-spring.xml
+++ b/b2c/src/main/resources/logback-spring.xml
@@ -2,7 +2,7 @@
 <configuration>
 
     <!-- 로그 패턴 설정 -->
-    <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [%thread] %logger{36} %msg%n"/>
+    <property name="LOG_PATTERN" value="[%d{yyyy-MM-dd HH:mm:ss.SSS}] [%-5level] [TRACE_ID: %X{traceId}] [%thread] %logger{36} %msg%n"/>
 
     <!-- ConsoleAppender 설정: 콘솔에 로그 출력 -->
     <appender name="CONSOLE" class="ch.qos.logback.core.ConsoleAppender">
@@ -43,6 +43,7 @@
 
     <!-- MDC 관련 로그 추가 예시 (traceId 설정) -->
     <logger name="com.sparta" level="INFO">
+        <appender-ref ref="CONSOLE"/>
         <appender-ref ref="DAILY_LOG"/>
     </logger>
 

--- a/common/src/main/java/com/sparta/common/interceptor/LoggingInterceptor.java
+++ b/common/src/main/java/com/sparta/common/interceptor/LoggingInterceptor.java
@@ -2,14 +2,16 @@ package com.sparta.common.interceptor;
 
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
-import org.springframework.stereotype.Component;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
+import org.springframework.stereotype.Component;
 import org.springframework.web.servlet.HandlerInterceptor;
-
 
 @Component
 public class LoggingInterceptor implements HandlerInterceptor {
 
+    private static final Logger logger = LoggerFactory.getLogger(LoggingInterceptor.class);
 
     @Override
     public boolean preHandle(HttpServletRequest request, HttpServletResponse response, Object handler) throws Exception {
@@ -18,20 +20,14 @@ public class LoggingInterceptor implements HandlerInterceptor {
         String traceId = MDC.get("traceId");
         String requestURI = request.getRequestURI();
 
-        // 요청 시작 로그
-        if (traceId != null) {
-            System.out.println("[TRACE_ID: " + traceId + "] Incoming request: " + requestURI);
-        }
-
         // 요청 시작 시간 기록 (후속 응답 시간 측정을 위해)
-        request.setAttribute("traceId", System.currentTimeMillis());
+        request.setAttribute("startTime", System.currentTimeMillis());
 
         return true;
     }
 
     @Override
     public void afterCompletion(HttpServletRequest request, HttpServletResponse response, Object handler, Exception ex) throws Exception {
-
         // 요청 처리 후 로그 (응답시간)
         Long startTime = (Long) request.getAttribute("startTime");
         Long endTime = System.currentTimeMillis();
@@ -40,9 +36,9 @@ public class LoggingInterceptor implements HandlerInterceptor {
         String traceId = MDC.get("traceId");
         String requestURI = request.getRequestURI();
 
-        // 응답 시간 로그
-        if (traceId != null) {
-            System.out.println("[TRACE_ID: " + traceId + "] Completed request: " + requestURI + " in " + duration + " ms");
-        }
+//        // 응답 시간 로그
+//        if (traceId != null) {
+//            logger.info("[TRACE_ID: {}] Completed request: {} in {} ms", traceId, requestURI, duration);
+//        }
     }
 }

--- a/common/src/main/java/com/sparta/common/interceptor/LoggingInterceptor.java
+++ b/common/src/main/java/com/sparta/common/interceptor/LoggingInterceptor.java
@@ -36,9 +36,5 @@ public class LoggingInterceptor implements HandlerInterceptor {
         String traceId = MDC.get("traceId");
         String requestURI = request.getRequestURI();
 
-//        // 응답 시간 로그
-//        if (traceId != null) {
-//            logger.info("[TRACE_ID: {}] Completed request: {} in {} ms", traceId, requestURI, duration);
-//        }
     }
 }

--- a/common/src/main/java/com/sparta/common/logging/LoggingAspect.java
+++ b/common/src/main/java/com/sparta/common/logging/LoggingAspect.java
@@ -4,6 +4,8 @@ import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
 import org.aspectj.lang.annotation.Pointcut;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.slf4j.MDC;
 import org.springframework.stereotype.Component;
 
@@ -14,7 +16,9 @@ import java.util.UUID;
 @Component
 public class LoggingAspect {
 
-    // 포인트컷 정의
+    private static final Logger logger = LoggerFactory.getLogger(LoggingAspect.class);
+
+    // 포인트컷 정의: com.sparta.controller 패키지 내의 모든 메서드에 적용
     @Pointcut("execution(* com.sparta..controller..*(..))")
     public void controllerMethods() {}
 
@@ -29,28 +33,16 @@ public class LoggingAspect {
             MDC.put("traceId", traceId); // MDC 에 traceId 설정
         }
 
+        // 메서드명 및 인자 추출
         String methodName = joinPoint.getSignature().getName();
         String methodArgs = Arrays.toString(joinPoint.getArgs());
 
-        // 요청 시작 시간 기록
-        Long startTime = System.currentTimeMillis();
-
-        // 로그: 메서드 호출 전
-        if (traceId != null) {
-            System.out.println("[TRACE_ID: " + traceId + "] Executing method: " + methodName + " with args: " + methodArgs);
-        }
+        // 로그를 찍고
+        logger.info("[TRACE_ID: {}] Executing method: {}", traceId, joinPoint.getSignature().getName());
 
         // 메서드 실행
         Object result = joinPoint.proceed();
 
-        // 요청 종료 시간 기록
-        Long endTime = System.currentTimeMillis();
-        Long duration = endTime - startTime;
-
-        // 로그: 메서드 호출 후
-        if (traceId != null) {
-            System.out.println("[TRACE_ID: " + traceId + "] Method: " + methodName + "completed in " + duration + " ms");
-        }
 
         return result;
     }

--- a/common/src/main/java/com/sparta/common/logging/TraceIdFilter.java
+++ b/common/src/main/java/com/sparta/common/logging/TraceIdFilter.java
@@ -3,22 +3,18 @@ package com.sparta.common.logging;
 import java.io.IOException;
 import java.util.UUID;
 
-import jakarta.servlet.Filter;
 import jakarta.servlet.FilterChain;
-import jakarta.servlet.FilterConfig;
 import jakarta.servlet.ServletException;
-import jakarta.servlet.ServletRequest;
-import jakarta.servlet.ServletResponse;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import org.slf4j.MDC;
+import org.springframework.web.filter.OncePerRequestFilter;
 
-public class TraceIdFilter implements Filter {
-
-    @Override
-    public void init(FilterConfig filterConfig) throws ServletException {
-    }
+public class TraceIdFilter extends OncePerRequestFilter {
 
     @Override
-    public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain) throws IOException, ServletException {
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain chain) throws ServletException, IOException {
+
         String traceId = UUID.randomUUID().toString(); // traceId 생성
         MDC.put("traceId", traceId); // MDC 에 traceId 설정
 
@@ -27,8 +23,8 @@ public class TraceIdFilter implements Filter {
             chain.doFilter(request, response);
         } finally {
             // 요청 후 MDC 에서 traceId 제거
-            MDC.remove("traceId");
+            MDC.clear();
         }
-    }
 
+    }
 }


### PR DESCRIPTION
## 🔘Part 
- 로깅

## 🔎 작업 내용 
<br>

1. Logback 설정:
    * logback.xml에 traceId를 로그 패턴에 추가.
    * ConsoleAppender와 RollingFileAppender를 통해 로그를 출력하도록 설정.
    * 로그 샘플: [2024-12-30 12:34:56.789] [INFO] [TRACE_ID: 123e4567-e89b-12d3-a456-426614174000] - 로그 메시지
2. TraceIdFilter 추가:
    * 모든 HTTP 요청마다 고유한 traceId를 생성하고 MDC에 저장.
    * 요청 처리 후 MDC에서 traceId를 제거하여 메모리 누수를 방지.
3. LoggingInterceptor 구현:
    * HTTP 요청 URI와 시작 시간을 기록.
    * 요청 완료 후 응답 시간(duration)을 로그로 출력.
4. AOP 기반 로깅:
    * LoggingAspect를 통해 com.sparta.controller 패키지의 메서드 실행 전후에 로깅 추가.
    * 메서드명, 인자, 실행 시간 등을 로그에 기록.
5. 구성 클래스 추가:
    * LogConfig를 통해 필터와 인터셉터를 등록.
적용 범위:
* /api/* 엔드포인트에 대해 TraceId 기반 로깅 적용.
* 컨트롤러 메서드 호출 시 AOP 로깅 활성화.
<br>


## 🔧 앞으로의 과제 
- 캐싱 영역 살펴보기

## ➕ 이슈 링크 
- #119 
