### PR TITLE
[#114] feat: B2B S3 고아 객체 삭제 

### DIFF
--- a/b2b/src/main/java/com/sparta/b2b/B2bApplication.java
+++ b/b2b/src/main/java/com/sparta/b2b/B2bApplication.java
@@ -2,8 +2,10 @@ package com.sparta.b2b;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication(scanBasePackages = {"com.sparta"})
+@EnableScheduling
 public class B2bApplication {
 
 	public static void main(String[] args) {

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/scheduler/FileDeleteScheduler.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/scheduler/FileDeleteScheduler.java
@@ -1,0 +1,24 @@
+package com.sparta.b2b.fileUpload.scheduler;
+
+import com.sparta.b2b.fileUpload.service.FileManageService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+
+@Slf4j
+@Component
+@RequiredArgsConstructor
+public class FileDeleteScheduler {
+
+	private final FileManageService fileManageService;
+
+	@Scheduled(cron = "0 0 0 3 * ?")
+	public void removeUnusedFiles() {
+
+		fileManageService.removeUnusedFiles();
+		log.info("call - removeUnusedFiles()");
+	}
+}
+

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/FileManageService.java
@@ -1,5 +1,6 @@
 package com.sparta.b2b.fileUpload.service;
 
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.sparta.b2b.fileUpload.dto.ImageUploadedResponse;
 import com.sparta.b2b.fileUpload.dto.ImageInfo;
 import com.sparta.b2b.fileUpload.dto.ImageUploadedResponseV2;
@@ -10,6 +11,7 @@ import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.web.multipart.MultipartFile;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -71,5 +73,16 @@ public class FileManageService {
 
 	public void delete(String imageUrl) {
 		s3ManageService.delete(imageUrl);
+	}
+
+
+	public void removeUnusedFiles() {
+		List<Image> unUsedImages = imageRepository.findAllByProductIsNull();
+		for (Image unUsedImage : unUsedImages) {
+			// S3에서 삭제
+			delete(unUsedImage.getImgUrl());
+			// DB에서 삭제
+			imageRepository.delete(unUsedImage);
+		}
 	}
 }

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -2,6 +2,7 @@ package com.sparta.b2b.fileUpload.service;
 
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.model.CannedAccessControlList;
+import com.amazonaws.services.s3.model.DeleteObjectRequest;
 import com.amazonaws.services.s3.model.ObjectMetadata;
 import com.amazonaws.services.s3.model.PutObjectRequest;
 import lombok.RequiredArgsConstructor;
@@ -46,7 +47,7 @@ public class S3ManageService {
 
 
 	public void delete(String imageUrl) {
-		String fileName = extractFileNameFromUrl(imageUrl);
+		String fileName = imageUrl.split("/")[5];
 		try {
 			amazonS3.deleteObject(bucket, fileName);
 			log.info("S3에서 파일 삭제 완료: {}", fileName);

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -64,5 +64,4 @@ public class S3ManageService {
 		}
 		return imageUrl.substring(bucketUrl.length());
 	}
-
 }

--- a/b2b/src/main/java/com/sparta/b2b/product/service/ProductService.java
+++ b/b2b/src/main/java/com/sparta/b2b/product/service/ProductService.java
@@ -152,7 +152,6 @@ public class ProductService {
 			fileManageService.delete(image.getImgUrl()); // S3 에서 삭제
 			imageRepository.delete(image); // DB에서 삭제
 		}
-
 		productRepository.deleteById(productId);
 	}
 }

--- a/b2b/src/main/resources/application-prod.yml
+++ b/b2b/src/main/resources/application-prod.yml
@@ -17,7 +17,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: update
+      ddl-auto: validate
     properties:
       hibernate:
         show_sql: true

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/image/repository/ImageRepository.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/image/repository/ImageRepository.java
@@ -11,4 +11,7 @@ public interface ImageRepository extends JpaRepository<Image, Long> {
 
 	List<Image> findAllByProduct(Product product);
 	List<Image> findByProductId(Long productId);
+
+	// 매핑이 안된 이미지들 모두 조회
+	List<Image> findAllByProductIsNull();
 }


### PR DESCRIPTION

## 🔘Part 
-AWS S3 고아 객체 삭제 

## 🔎 작업 내용 
- AWS S3 고아 객체 삭제 구현
  - 상품과 매핑 되지 않은 이미지 삭제
- 폴더 생성으로 이미지가 삭제 되지 않던 애러 해결 

## ➕ 이슈 링크 
- #114 
