### PR TITLE
[#133] feat: B2C 상품 검색 시 인덱스를 통한 성능 개선

### DIFF
--- a/b2c/src/main/java/com/sparta/b2c/product/controller/ProductController.java
+++ b/b2c/src/main/java/com/sparta/b2c/product/controller/ProductController.java
@@ -35,7 +35,7 @@ public class ProductController {
             @RequestParam(defaultValue = "1") int page,
             @RequestParam(defaultValue = "10") int size,
             @RequestParam(defaultValue = "") String keyword,
-            @RequestParam(defaultValue = "asc") String orderBy,
+            @RequestParam(defaultValue = "ASC") String orderBy,
             @RequestParam(defaultValue = "name") String sortBy,
             @RequestParam(defaultValue = "DEFAULT") Category category,
             @RequestParam(defaultValue = "DEFAULT") Category.SubCategory subCategory

--- a/b2c/src/main/resources/application.yml
+++ b/b2c/src/main/resources/application.yml
@@ -34,7 +34,14 @@ spring:
     redis:
       host: 127.0.0.1
       port: 6380
-
+logging:
+  level:
+    org:
+      hibernate:
+        sql: DEBUG
+        orm:
+          jdbc:
+            bind: trace
 cloud:
   aws:
     s3:

--- a/b2c/src/test/java/com/sparta/b2c/product/ProductCsvFileGenerationTest.java
+++ b/b2c/src/test/java/com/sparta/b2c/product/ProductCsvFileGenerationTest.java
@@ -1,0 +1,82 @@
+package com.sparta.b2c.product;
+
+import com.sparta.impostor.commerce.backend.domain.product.enums.Category;
+import org.junit.jupiter.api.Disabled;
+import org.junit.jupiter.api.Test;
+
+import java.io.FileWriter;
+import java.io.IOException;
+import java.text.SimpleDateFormat;
+import java.util.Calendar;
+import java.util.Date;
+import java.util.Random;
+
+class ProductCsvFileGenerationTest {
+
+    private static final String CSV_FILE_PATH = "products.csv";
+
+    // 사용을 원할시 Disabled 어노테이션을 삭제할 것
+    @Disabled("더미 데이터 100만건 csv파일 생성 테스트코드")
+    @Test
+    public void generateCsvTest() throws IOException {
+        int numberOfRecords = 1000000;
+
+        FileWriter writer = new FileWriter(CSV_FILE_PATH);
+
+        writer.append("id,name,description,price,status,category,sub_category,member_id,created_at,modified_at\n");
+
+        Random random = new Random();
+        SimpleDateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd HH:mm:ss");
+        Calendar calendar = Calendar.getInstance();
+        calendar.add(Calendar.YEAR, -1);
+        Date oneYearAgo = calendar.getTime();
+
+        for (int i = 1; i <= numberOfRecords; i++) {
+            String id = String.valueOf(i);
+            char randomChar1 = (char) ('a' + random.nextInt(26));
+            char randomChar2 = (char) ('a' + random.nextInt(26));
+            String name = "상품" + randomChar1 + randomChar2;
+            String description = "상품 설명";
+            int price = random.nextInt(999901) + 100; // 100 ~ 1000000 사이의 랜덤 가격
+
+            String status = getWeightedStatus(random);
+
+            Category[] categories = Category.values();
+            Category category = categories[random.nextInt(categories.length)];
+            Category.SubCategory[] subCategories = category.getSubCategories();
+            Category.SubCategory subCategory = subCategories[random.nextInt(subCategories.length)];
+
+            long randomTime = oneYearAgo.getTime() + (long) (random.nextDouble() * (new Date().getTime() - oneYearAgo.getTime()));
+            String randomDate = dateFormat.format(new Date(randomTime));
+
+            String memberId = "1";
+            String createdAt = randomDate;
+            String modifiedAt = randomDate;
+
+            writer.append(id).append(",")
+                    .append(name).append(",")
+                    .append(description).append(",")
+                    .append(String.valueOf(price)).append(",")
+                    .append(status).append(",")
+                    .append(category.name()).append(",")
+                    .append(subCategory.name()).append(",")
+                    .append(memberId).append(",")
+                    .append(createdAt).append(",")
+                    .append(modifiedAt).append("\n");
+        }
+
+        writer.flush();
+        writer.close();
+    }
+
+    private String getWeightedStatus(Random random) {
+        int weightedRandom = random.nextInt(100); // 0~99
+        if (weightedRandom < 70) {
+            return "ON_SALE"; // 70% 확률
+        } else if (weightedRandom < 90) {
+            return "PENDING"; // 20% 확률 (70~89)
+        } else {
+            return "OFF_SALE"; // 10% 확률 (90~99)
+        }
+    }
+}

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/repository/ProductRepositoryQueryImpl.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/repository/ProductRepositoryQueryImpl.java
@@ -43,16 +43,18 @@ public class ProductRepositoryQueryImpl implements ProductRepositoryQuery {
             Pageable pageable
     ) {
         BooleanBuilder whereClause = new BooleanBuilder();
+        whereClause.and(product.price.gt(0));
+        if (category != Category.DEFAULT) {
+            whereClause.and(product.category.eq(category));
+        }
+        if (subCategory != Category.SubCategory.DEFAULT) {
+            whereClause.and(product.subCategory.eq(subCategory));
+        }
         if (keyword != null && !keyword.isEmpty()) {
-            whereClause.and(product.name.containsIgnoreCase(keyword));
+            whereClause.and(product.name.contains(keyword));
         }
         if (productStatus != null) {
             whereClause.and(product.status.eq(productStatus));
-        }
-        if (category != Category.DEFAULT) {
-            whereClause.and(product.category.eq(category));
-        } else if (subCategory != Category.SubCategory.DEFAULT) {
-            whereClause.and(product.subCategory.eq(subCategory));
         }
         JPAQuery<?> baseQuery = jpaQueryFactory.from(product).where(whereClause);
 

--- a/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/repository/ProductRepositoryQueryImpl.java
+++ b/domain/src/main/java/com/sparta/impostor/commerce/backend/domain/product/repository/ProductRepositoryQueryImpl.java
@@ -2,12 +2,9 @@ package com.sparta.impostor.commerce.backend.domain.product.repository;
 
 
 import com.querydsl.core.BooleanBuilder;
-import com.querydsl.core.types.Expression;
 import com.querydsl.core.types.Order;
 import com.querydsl.core.types.OrderSpecifier;
-import com.querydsl.core.types.Path;
 import com.querydsl.core.types.dsl.BooleanExpression;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.PathBuilder;
 import com.querydsl.jpa.impl.JPAQuery;
 import com.querydsl.jpa.impl.JPAQueryFactory;

--- a/scripts/Index.sql
+++ b/scripts/Index.sql
@@ -14,7 +14,7 @@ SELECT sub_category, COUNT(*) AS cnt,
        (COUNT(*) * 100.0 / (SELECT COUNT(*) FROM product)) AS percentage_of_total
 FROM product
 WHERE name like '%상품%'
-GROUP BY category;
+GROUP BY sub_category;
 
 # 상품 검색 실행계획 확인 쿼리
 explain

--- a/scripts/Index.sql
+++ b/scripts/Index.sql
@@ -1,0 +1,41 @@
+# DB 선택
+USE impostor;
+
+# 인덱스 추가
+CREATE INDEX idx_product_price ON product(price);
+CREATE INDEX idx_product_sub_category ON product(sub_category);
+CREATE INDEX idx_product_created_at ON product(created_at);
+
+# product 테이블의 전체 인덱스 보기
+SHOW INDEX FROM product;
+
+# 전체 데이터 중 각 서브 카테고리별 개수 및 비율 확인 쿼리
+SELECT sub_category, COUNT(*) AS cnt,
+       (COUNT(*) * 100.0 / (SELECT COUNT(*) FROM product)) AS percentage_of_total
+FROM product
+WHERE name like '%상품%'
+GROUP BY category;
+
+# 상품 검색 실행계획 확인 쿼리
+explain
+select
+    p1_0.id,
+    p1_0.category,
+    p1_0.created_at,
+    p1_0.description,
+    p1_0.member_id,
+    p1_0.modified_at,
+    p1_0.name,
+    p1_0.price,
+    p1_0.status,
+    p1_0.stock_quantity,
+    p1_0.sub_category
+from product p1_0
+where
+    p1_0.category='TOP'
+  and p1_0.sub_category='SHIRT'
+  and p1_0.name like '%상품%' escape '!'
+    and p1_0.status='ON_SALE'
+order by
+    p1_0.price
+limit 0, 10;

--- a/scripts/ProductDataInput.sql
+++ b/scripts/ProductDataInput.sql
@@ -1,0 +1,9 @@
+use impostor;
+
+LOAD DATA INFILE '/var/lib/mysql-files/products.csv'
+    INTO TABLE product
+    FIELDS TERMINATED BY ','
+    ENCLOSED BY '"'
+    LINES TERMINATED BY '\n'
+    IGNORE 1 LINES
+    (id, name, description, price, status, category, sub_category, member_id, created_at, modified_at);


### PR DESCRIPTION
## 🔘Part 
- B2C 상품 검색 시 인덱스를 통한 성능 개선

## 🔎 작업 내용 
- product 테이블에 `price`, `sub_category`, `created_at` 세 개의 인덱스 추가
- csv 파일을 생성하는 테스트 코드 추가
- 생성된 csv 파일을 DB에 집어넣는 쿼리 추가
- ProductController 에서 상품 검색 시 orderBy에 적용되는 기본값 대문자로 변경
- B2C에서 하이버네이트 로그에 바인딩 되는 값 보이게 변경

## 🔧 앞으로의 과제 
- 먼 훗날 성능 한계에 부딪힐 시 외부 서비스(ElasticSearch)를 고려

## ➕ 이슈 링크 
- #133 
