### PR TITLE
[#114] feat: B2B 이미지 삭제 로직 수정 및 데스트 로직 추가

### DIFF
--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/controller/FileUploadController.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/controller/FileUploadController.java
@@ -43,4 +43,12 @@ public class FileUploadController {
 			.status(HttpStatus.CREATED)
 			.body(fileUploadService.uploadFileV2(file, memberSession.memberId()));
 	}
+
+	//scheduler 호출
+	@CheckAuth(role = Role.B2B)
+	@GetMapping("/test")
+	public ResponseEntity<Void> test() {
+		fileUploadService.removeUnusedFiles();
+		return ResponseEntity.ok().build();
+	}
 }

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -58,7 +58,7 @@ public class S3ManageService {
 
 			log.info("3333");
 
-			amazonS3.deleteObject(bucket, "/product-image/" + fileName);
+			amazonS3.deleteObject(bucket, fileName);
 
 			log.info("444");
 			log.info("S3에서 파일 삭제 완료: {}", fileName);

--- a/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
+++ b/b2b/src/main/java/com/sparta/b2b/fileUpload/service/S3ManageService.java
@@ -46,13 +46,28 @@ public class S3ManageService {
 	}
 
 
+
 	public void delete(String imageUrl) {
-		String fileName = imageUrl.split("/")[5];
+		log.info("1111111111111111111111111");
+
+		String[] split = imageUrl.split("/");
+		String fileName = split[split.length - 1];
+
+		log.info("222222");
 		try {
-			amazonS3.deleteObject(bucket, fileName);
+
+			log.info("3333");
+
+			amazonS3.deleteObject(bucket, "/product-image/" + fileName);
+
+			log.info("444");
 			log.info("S3에서 파일 삭제 완료: {}", fileName);
+			log.info("5555");
+
 		} catch (Exception e) {
+			log.info("6666");
 			log.error("S3에서 파일 삭제 실패: {}", fileName, e);
+			log.info("77777");
 		}
 	}
 

--- a/b2b/src/test/java/com/sparta/b2b/fileUpload/FileValidationTest.java
+++ b/b2b/src/test/java/com/sparta/b2b/fileUpload/FileValidationTest.java
@@ -19,7 +19,7 @@ public class FileValidationTest {
 	@Test
 	void validateFiles_shouldThrowException_whenFilesAreNull() {
 		// given
-		FileManageService fileManageService = new FileManageService(null,null);
+		FileManageService fileManageService = new FileManageService(null,null, null);
 
 		// when
 		EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
@@ -31,7 +31,7 @@ public class FileValidationTest {
 
 	@Test
 	void validateFiles_shouldThrowException_whenFilesAreEmpty() {
-		FileManageService fileManageService = new FileManageService(null,null);
+		FileManageService fileManageService = new FileManageService(null,null, null);
 
 		EntityNotFoundException exception = assertThrows(EntityNotFoundException.class,
 			() -> fileManageService.validateFiles(Collections.emptyList()));
@@ -41,7 +41,7 @@ public class FileValidationTest {
 
 	@Test
 	void validateFiles_shouldThrowException_whenFileCountExceedsLimit() {
-		FileManageService fileManageService = new FileManageService(null,null);
+		FileManageService fileManageService = new FileManageService(null,null, null);
 
 		List<MultipartFile> files = new ArrayList<>();
 		for (int i = 0; i < 11; i++) {
@@ -56,7 +56,7 @@ public class FileValidationTest {
 
 	@Test
 	void validateFiles_shouldThrowException_whenFileIsNullOrEmpty() {
-		FileManageService fileManageService = new FileManageService(null,null);
+		FileManageService fileManageService = new FileManageService(null,null, null);
 
 		MultipartFile emptyFile = Mockito.mock(MultipartFile.class);
 		Mockito.when(emptyFile.isEmpty()).thenReturn(true);
@@ -71,7 +71,7 @@ public class FileValidationTest {
 
 	@Test
 	void validateFiles_shouldPass_whenAllFilesAreValid() {
-		FileManageService fileManageService = new FileManageService(null,null);
+		FileManageService fileManageService = new FileManageService(null,null, null);
 
 		MultipartFile validFile = Mockito.mock(MultipartFile.class);
 		Mockito.when(validFile.isEmpty()).thenReturn(false);

--- a/b2b/src/test/java/com/sparta/b2b/study/SplitTest.java
+++ b/b2b/src/test/java/com/sparta/b2b/study/SplitTest.java
@@ -1,0 +1,27 @@
+package com.sparta.b2b.study;
+
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+public class SplitTest {
+
+	@DisplayName("파일명 추출 테스트")
+	@Test
+	void fileNameSplitTest() {
+
+		// 1. S3 https://impostor-s3bucket.s3.ap-northeast-2.amazonaws.com/product-image/0f55c81b-2fe0-47d9-a242-6244aab09ed8.jpg
+		// 2 로컬스텍 http://localhost:4566/local-bucket/product-image/bf79c0dd-b45c-4c58-b251-92c1d275d77b.jpg
+		String s3FileUrl = "https://impostor-s3bucket.s3.ap-northeast-2.amazonaws.com/product-image/0f55c81b-2fe0-47d9-a242-6244aab09ed8.jpg";
+		String localStackFileUrl = "http://localhost:4566/local-bucket/product-image/bf79c0dd-b45c-4c58-b251-92c1d275d77b.jpg";
+
+		String[] s3Split = s3FileUrl.split("/");
+		String s3FileName = s3Split[s3Split.length - 1];
+
+		String[] localStackSplit = localStackFileUrl.split("/");
+		String localStackFileName = localStackSplit[localStackSplit.length - 1];
+
+		Assertions.assertThat(s3FileName).isEqualTo("0f55c81b-2fe0-47d9-a242-6244aab09ed8.jpg");
+		Assertions.assertThat(localStackFileName).isEqualTo("bf79c0dd-b45c-4c58-b251-92c1d275d77b.jpg");
+	}
+}


### PR DESCRIPTION


## 🔘Part 
- B2B 이미지 삭제 로직 수정 및 데스트 로직 추가

## 🔎 작업 내용 
-  B2B 이미지 삭제 로직 수정 
- url 데스트 추가
- 이미지 생성 시 권한 검증 로직 추가

## 🔧 앞으로의 과제 
- 이미지 삭제 로직 리펙토링

## ➕ 이슈 링크 
- #114 
